### PR TITLE
fix: Prioritize special queue param defaults over queue env defaults

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
@@ -9,7 +9,7 @@ from deadline.client.api._queue_parameters import get_queue_parameter_definition
 
 
 _QUEUE_ENVIRONMENT_SPECIAL_DEFAULTS = {
-    "RezPackages": "houdini",
+    "RezPackages": "houdini deadline_cloud_for_houdini",
 }
 
 
@@ -140,10 +140,10 @@ def _get_equivalent_bool(original_value: str) -> Optional[bool]:
 
 
 def _get_default_value(param: dict[str, Any]) -> tuple[Union[str, int, float], ...]:
-    if "default" in param:
-        return (param["default"],)
-    elif param["name"] in _QUEUE_ENVIRONMENT_SPECIAL_DEFAULTS:
+    if param["name"] in _QUEUE_ENVIRONMENT_SPECIAL_DEFAULTS:
         return (_QUEUE_ENVIRONMENT_SPECIAL_DEFAULTS[param["name"]],)
+    elif "default" in param:
+        return (param["default"],)
     else:
         return ()
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Houdini submitter prioritized default values for queue environment parameters incorrectly. A parameter requires a default, so the special case defaults that the submitter uses were never actually applied. This is particularly important for the parameter "RezPackages" because the queue environment typically will not have a good default because it will be different for each DCC. Because the default Queue environment that most customers will be using uses the empty string as a default, the "RezPackages" parameter would never be populated with anything useful unless the user manually specified something.

### What was the solution? (How)
Switch the logic around to prioritize overriding the default with the special case default if one exists.

### What is the impact of this change?
The field will automatically be populated with "houdini deadline_cloud_for_houdini" so the user will not need to manually specify the packages.

### How was this change tested?
I created a DeadlineCloud node and observed that it overrode the value while populating the defaults in the UI.

### Was this change documented?
N/A

### Is this a breaking change?
No, this is a fixing change.