### PR TITLE
chore: Update dependency to deadline-cloud 0.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.9"
 
 dependencies = [
-    "deadline == 0.36.*",
+    "deadline == 0.37.*",
     "openjd-adaptor-runtime == 0.3.*",
 ]
 


### PR DESCRIPTION
## Summary

Bumps the deadline-cloud dependency to 0.37.*
