### PR TITLE
chore: add supported version to description

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_houdini</name>
-    <description>Deadline Cloud for Houdini</description>
-    <detailedDescription>Houdini plugin for submitting jobs to Amazon Deadline Cloud.</detailedDescription>
+    <description>Deadline Cloud for Houdini 19.5</description>
+    <detailedDescription>Houdini plugin for submitting jobs to Amazon Deadline Cloud. Compatible with Houdini 19.5.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -75,8 +75,9 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_houdini_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Houdini
-- Install the integrated Houdini submitter files to the installation directory
+			<value>Deadline Cloud for Houdini 19.5
+- Compatible with Houdini 19.5.
+- Install the integrated Houdini submitter files to the installation directory.
 - Register the plug-in with Houdini by installing and configuring a package file.</value>
 		</stringParameter>
 	</parameterList>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It was unclear at installation time what version(s) of the DCC the submitter will be available in.

### What was the solution? (How)

Explicitly call out which version(s) of the DCC the submitter will be available in.

### What is the impact of this change?

Less confusion when installing

### How was this change tested?

Built an installer, confirmed wording appeared accurate:

![image](https://github.com/casillas2/deadline-cloud-for-houdini/assets/119458760/afed3904-4598-41a1-beb2-f4c219b29bde)

### Was this change documented?

No

### Is this a breaking change?

No