### PR TITLE
fix: use proper rez syntax for RezPackages queue environment

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
@@ -141,7 +141,7 @@ def _get_default_value(param: JobParameter) -> tuple[Union[str, int, float], ...
     adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
 
     if param["name"] == "RezPackages":
-        return (f"houdini-{houdini_version}.* deadline_cloud_for_houdini",)
+        return (f"houdini-{houdini_version} deadline_cloud_for_houdini",)
     elif param["name"] == "CondaPackages":
         return (f"houdini={houdini_version}.* houdini-openjd={adaptor_version}.*",)
     elif "default" in param:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

RezPackages queue env variable had some conda syntax sneak into it

### What was the solution? (How)

remove it!

### What is the impact of this change?

Default values for RezPackages are accurate again

### How was this change tested?

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Fixing!