### PR TITLE
fix: make 0 the min for failed tasks and retry limit

### DIFF
--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/DialogScript
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/DialogScript
@@ -606,7 +606,7 @@
                 label   "Failed Tasks Limit"
                 type    integer
                 default { "20" }
-                range   { 1 200 }
+                range   { 0 200 }
                 parmtag { "script_callback_language" "python" }
             }
             parm {
@@ -614,7 +614,7 @@
                 label   "Task Retry Limit"
                 type    integer
                 default { "5" }
-                range   { 1 10 }
+                range   { 0 10 }
                 parmtag { "script_callback_language" "python" }
             }
         }


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

we have minimums of 1 for failed task limit and max retries. They should be 0!

### What was the solution? (How)

make it so

### What is the impact of this change?

you can use the fancy scroll bars to make them 0! instead of manually selecting it to be 0

### How was this change tested?

hatch run install and verified the change applied properly

https://github.com/casillas2/deadline-cloud-for-houdini/assets/60796713/b3cf5d7d-234f-47cf-b16c-656522eb6c6b

### Was this change documented?

N/A

### Is this a breaking change?

No