### PR TITLE
chore: add dependabot auto-merge

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -13,9 +13,16 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: approve and enable auto-merge
+        run: | 
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: second approval
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.APPROVAL_TOKEN }}

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -63,6 +63,7 @@ jobs:
           # Run semantic-release to generate new changelog
           pip install --upgrade hatch
           hatch env create release
+          hatch run release:deps
           NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
 
           # Grab the new version's changelog and prepend it to the original changelog contents

--- a/hatch.toml
+++ b/hatch.toml
@@ -43,10 +43,8 @@ test = "pytest --no-cov {args:test/*/e2e}"
 
 [envs.release]
 detached = true
-dependencies = [
-  "python-semantic-release == 8.7.*"
-]
 
 [envs.release.scripts]
+deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,3 +1,1 @@
-# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
-# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
 python-semantic-release == 8.7.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Add auto-merge to dependabot PRs if all status checks pass.

### What was the solution? (How)
* Add a second approval to meet two approval requirements.
* Add an action to enable auto-merge with squash
* Update hatch.toml so that python-semantic-release is installed using the requirements-release.txt.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions

### What is the impact of this change?
Dependabot PRs will now automerge if all mandatory status checks pass.

### How was this change tested?
Tested in a developer github account

### Was this change documented?
no

### Is this a breaking change?
no