### PR TITLE
chore: update deps deadline-cloud 0.40

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.9"
 
 dependencies = [
-    "deadline == 0.39.*",
+    "deadline == 0.40.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A new version of deadline-cloud was released and we should upgrade to it.
### What was the solution? (How)

### Upgrade to the latest deadline-cloud
What is the impact of this change?

### Upgrade to the latest deadline-cloud
How was this change tested?

hatch build && hatch run test
### Was this change documented?
no
### Is this a breaking change?
no