### PR TITLE
feat: Adds telemetry events to submitter and adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ You can download this package from:
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.9"
 
 dependencies = [
-    "deadline == 0.40.*",
+    "deadline == 0.41.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 

--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_client.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_client.py
@@ -32,6 +32,7 @@ class HoudiniClient(HTTPClientInterface):
 
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
+        print(f"HoudiniClient: Houdini Version {hou.applicationVersionString()}")
         self.actions.update(HoudiniHandler().action_dict)
 
     def close(self, args: Optional[dict] = None) -> None:

--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/INDEX__SECTION
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/INDEX__SECTION
@@ -10,5 +10,5 @@ Inputs:       1 to 1000
 Subnet:       false
 Python:       false
 Empty:        false
-Modified:     Tue Dec 19 15:44:57 2023
+Modified:     Mon Mar 18 13:31:43 2024
 

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -20,6 +20,7 @@ from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentS3Settings
 
 from .queue_parameters import update_queue_parameters, get_queue_parameter_values_as_openjd
+from ._version import version
 
 import hou
 
@@ -330,6 +331,13 @@ def p_submit(kwargs):
     queue_parameters: list[JobParameter] = []
     asset_references = _get_asset_references(node)
     try:
+        # Initialize telemetry client, opt-out is respected
+        api.get_deadline_cloud_library_telemetry_client().update_common_details(
+            {
+                "deadline-cloud-for-houdini-submitter-version": version,
+                "houdini-version": _get_houdini_version(),
+            }
+        )
         deadline = api.get_boto3_client("deadline")
 
         job_bundle_dir = create_job_history_bundle_dir("houdini", name)

--- a/test/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py
@@ -54,6 +54,9 @@ def mock_config() -> Generator[Mock, None, None]:
 
 
 class TestHoudiniAdaptor_on_start:
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -62,6 +65,7 @@ class TestHoudiniAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         init_data: dict,
     ) -> None:
         """Tests that on_start completes without error"""
@@ -70,6 +74,9 @@ class TestHoudiniAdaptor_on_start:
         adaptor.on_start()
 
     @patch("time.sleep")
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -78,6 +85,7 @@ class TestHoudiniAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
     ) -> None:
@@ -177,6 +185,9 @@ class TestHoudiniAdaptor_on_start:
         assert str(exc_info.value) == error_msg
 
     @patch.object(HoudiniAdaptor, "_houdini_is_running", False)
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=1)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -185,6 +196,7 @@ class TestHoudiniAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         init_data: dict,
     ) -> None:
         """
@@ -205,12 +217,16 @@ class TestHoudiniAdaptor_on_start:
         assert str(exc_info.value) == error_msg
 
     @patch.object(HoudiniAdaptor, "_action_queue")
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
     def test_populate_action_queue(
         self,
         mock_server: Mock,
         mock_logging_subprocess: Mock,
+        mock_telemetry_client: Mock,
         mock_actions_queue: Mock,
         init_data: dict,
     ) -> None:
@@ -270,6 +286,9 @@ class TestHoudiniAdaptor_on_start:
 
 class TestHoudiniAdaptor_on_run:
     @patch("time.sleep")
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -278,6 +297,7 @@ class TestHoudiniAdaptor_on_run:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
         run_data: dict,
@@ -306,6 +326,9 @@ class TestHoudiniAdaptor_on_run:
         "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._houdini_is_running",
         new_callable=PropertyMock,
     )
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -314,6 +337,7 @@ class TestHoudiniAdaptor_on_run:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_houdini_is_running: Mock,
         mock_is_rendering: Mock,
         mock_sleep: Mock,
@@ -343,6 +367,9 @@ class TestHoudiniAdaptor_on_run:
 
 class TestHoudiniAdaptor_on_stop:
     @patch("time.sleep")
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -351,6 +378,7 @@ class TestHoudiniAdaptor_on_stop:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
         run_data: dict,
@@ -429,6 +457,9 @@ class TestHoudiniAdaptor_on_cleanup:
         mock_server_thread.join.assert_called_once_with(timeout=0.01)
 
     @patch("time.sleep")
+    @patch(
+        "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.LoggingSubprocess")
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.AdaptorServer")
@@ -437,6 +468,7 @@ class TestHoudiniAdaptor_on_cleanup:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
         run_data: dict,
@@ -596,6 +628,22 @@ class TestHoudiniAdaptor_on_cleanup:
 
         # THEN
         assert not match
+
+    def test_handle_version(self, init_data: dict):
+        """Tests that the _handle_houdini_version method reports the version correctly"""
+        # GIVEN
+        VERSION_CALLBACK_INDEX = 3
+        adaptor = HoudiniAdaptor(init_data)
+        regex_callbacks = adaptor._get_regex_callbacks()
+        complete_regex = regex_callbacks[VERSION_CALLBACK_INDEX].regex_list[0]
+
+        # WHEN
+        match = complete_regex.search("HoudiniClient: Houdini Version 19.5.435")
+        assert match is not None
+        adaptor._handle_houdini_version(match)
+
+        # THEN
+        assert adaptor._houdini_version == "19.5.435"
 
     @pytest.mark.parametrize("adaptor_exc_info", [RuntimeError("Something Bad Happened!")])
     def test_has_adaptor_exception(

--- a/test/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py
+++ b/test/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py
@@ -16,3 +16,6 @@ setattr(this_module, "node", MagicMock(name=module_name + ".node"))
 setattr(this_module, "hipFile", Mock(name=module_name + ".hipFile"))
 setattr(this_module, "LoadWarning", Mock(name=module_name + ".LoadWarning"))
 setattr(this_module, "Node", Mock(name=module_name + ".Node"))
+setattr(
+    this_module, "applicationVersionString", Mock(name=module_name + ".applicationVersionString")
+)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We can't currently tell if anyone is using houdini submitters / adaptors

### What was the solution? (How)
Uses changes from https://github.com/casillas2/deadline-cloud/pull/205 to capture more package information when sending telemetry data, and changes from https://github.com/casillas2/deadline-cloud/pull/212 to opt out of telemetry from an environment variable.

### What is the impact of this change?
We can better tell how customers use our software and if they use Houdini

### How was this change tested?

-  ran the integrated submitter, and submitted a job, verifying it wrote telemetry (and didn't when opted out)
- ran the adaptor locally, confirming it wrote telemetry (and didn't when opted out)
- ran unit tests using deadline-cloud changes from mainline, they passed

### Was this change documented?
Updated README with opt out instructions

### Is this a breaking change?
No