### PR TITLE
fix: throw error on out of bounds wedgenum

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -21,7 +21,7 @@ lint = [
 ]
 install = "python {root}/scripts/install_dev_submitter.py {args:}"
 
-[[envs.test.matrix]]
+[[envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]

--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -101,7 +101,7 @@ class HoudiniHandler:
                 print(f"Applying wedge: {wedgenum}")
                 hm.applyspecificwedge(self.wedge, wl)
             else:
-                print(f"WEDGENUM out of range: {wedgenum}")
+                raise ValueError(f"WEDGENUM out of range: {wedgenum}")
 
         increment = 1
         self.node.parm("trange").set(1)

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Union
 
 import hou
 
-from ._version import version_tuple as adaptor_version_tuple  # type: ignore
+from ._version import version_tuple as adaptor_version_tuple
 from deadline.client.api._queue_parameters import get_queue_parameter_definitions
 from deadline.client.job_bundle.parameters import JobParameter
 

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -20,7 +20,7 @@ from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentS3Settings
 
 from .queue_parameters import update_queue_parameters, get_queue_parameter_values_as_openjd
-from ._version import version  # type: ignore
+from ._version import version
 
 import hou
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some unaddressed feedback in https://github.com/casillas2/deadline-cloud-for-houdini/pull/52

Also a QOL fix which makes it so that we define the hatch matrix using the name `all` across all our repos. This was previous inconsistent between `all` and `test`. 

For instance, makes it so that you can run tests against all python versions by running the command

```
hatch run all:test
```
### What was the solution? (How)
Address it

### What is the impact of this change?
Only functional change is we throw an error when a value is out of range
### How was this change tested?
`hatch run test`
### Was this change documented?
Will be on release
### Is this a breaking change?
No*