### PR TITLE
fix: safely handle potential deps when not submitting step deps

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -362,7 +362,9 @@ def _get_job_template(rop: hou.Node) -> dict[str, Any]:
         # up each node by step
         connected_node = rop_steps[-1]
         # remove deps, as only 1 step
-        del connected_node["dependency_names"]
+        connected_node.pop("dependency_names", None)
+        # remove dependency info from name
+        connected_node["name"] = connected_node["rop"]
         rop_steps = [connected_node]
         ignore_input_nodes = "false"
     for node in rop_steps:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Submitting without step dependencies would fail if there were no `dependency_names` in the node. ie. if the node we were submitting didn't have any dependencies to render.

### What was the solution? (How)

Do a safe delete of the dependency names, and at the same time, fix the name of the step to just be the ROP name instead of `{ROP Name}-{render_order}`.

### What is the impact of this change?

More workflows work

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
hatch shell
hatch run install
```

Launched Houdini and was able to submit jobs that contained nodes with and without deps, when "submit step deps" was not enabled.

### Was this change documented?

N/A

### Is this a breaking change?

Nope