### PR TITLE
docs: update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,38 +3,38 @@
 
 
 ### Bug Fixes
-* differentiate between required and optional init keys (#100) ([`c2dd76b`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/c2dd76b34be516c0781a370c97e2d353d0f9b7f5))
+* differentiate between required and optional init keys (#100) ([`c2dd76b`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/c2dd76b34be516c0781a370c97e2d353d0f9b7f5))
 
 ## 0.5.2 (2024-03-26)
 
 
 ### Features
-* Additional renderers and Wedge support (#52) ([`cad0931`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/cad0931c60b1bc42117ed8d1c3233925ecd42e26))
-* Adds telemetry events to submitter and adaptor (#89) ([`96e3c44`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/96e3c44e85bda47dfb59fae9580485e1592316c0))
+* Additional renderers and Wedge support (#52) ([`cad0931`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/cad0931c60b1bc42117ed8d1c3233925ecd42e26))
+* Adds telemetry events to submitter and adaptor (#89) ([`96e3c44`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/96e3c44e85bda47dfb59fae9580485e1592316c0))
 
 ### Bug Fixes
-* include deadline-cloud in the adaptor packaging script (#97) ([`fc2cb3d`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/fc2cb3d619126fb9ca291ec090fa297b773fe558))
-* throw error on out of bounds wedgenum (#96) ([`cc6aed9`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/cc6aed9a16a1a4152ed625738d351d20a5fbf885))
+* include deadline-cloud in the adaptor packaging script (#97) ([`fc2cb3d`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/fc2cb3d619126fb9ca291ec090fa297b773fe558))
+* throw error on out of bounds wedgenum (#96) ([`cc6aed9`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/cc6aed9a16a1a4152ed625738d351d20a5fbf885))
 
 ## 0.5.1 (2024-03-15)
 
 ### Chores
-* update deps deadline-cloud 0.40 (#87) ([`92497cf`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/92497cf0f3d116249f0c126bbbe30902286dd0b1))
+* update deps deadline-cloud 0.40 (#87) ([`92497cf`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/92497cf0f3d116249f0c126bbbe30902286dd0b1))
 
 ## 0.5.0 (2024-03-08)
 
 ### BREAKING CHANGES
-* **deps**: update openjd-adaptor-runtime to 0.5 (#83) ([`d661bdf`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/d661bdfd993733fdf401a3ffe34c23ba7dc8ca19))
+* **deps**: update openjd-adaptor-runtime to 0.5 (#83) ([`d661bdf`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/d661bdfd993733fdf401a3ffe34c23ba7dc8ca19))
 
 
 ### Bug Fixes
-* make 0 the min for failed tasks and retry limit (#79) ([`aeba186`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/aeba18620d7f3ac8ba4c177de547f6ace5856b9a))
-* use proper rez syntax for RezPackages (#77) ([`f1cd928`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/f1cd9287e910d7e47adaff04b782312a36a561be))
+* make 0 the min for failed tasks and retry limit (#79) ([`aeba186`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/aeba18620d7f3ac8ba4c177de547f6ace5856b9a))
+* use proper rez syntax for RezPackages (#77) ([`f1cd928`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/f1cd9287e910d7e47adaff04b782312a36a561be))
 
 ## 0.4.0 (2024-02-21)
 
 ### BREAKING CHANGES
-* Create a script to build adaptor package artifacts (#66) ([`d4f39a2`](https://github.com/casillas2/deadline-cloud-for-houdini/commit/d4f39a2e4bc959e5edb326d42c87e81bdfb6bfa4))
+* Create a script to build adaptor package artifacts (#66) ([`d4f39a2`](https://github.com/aws-deadline/deadline-cloud-for-houdini/commit/d4f39a2e4bc959e5edb326d42c87e81bdfb6bfa4))
 
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,48 @@
-# AWS Deadline Cloud for Houdini Development
+# Development documentation
+
+This package has two active branches:
+
+- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
+- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
+
+## Build / Test / Release
+
+### Build the package
+
+```bash
+hatch build
+```
+
+### Run tests
+
+```bash
+hatch run test
+```
+
+### Run linting
+
+```bash
+hatch run lint
+```
+
+### Run formatting
+
+```bash
+hatch run fmt
+```
+
+## Run tests for all supported Python versions
+
+```bash
+hatch run all:test
+```
+
+## Use development Submitter in Houdini
+
+```bash
+hatch run install
+```
+A development version of the Deadline Cloud node is then available in `/out` by pressing TAB, typing `deadline`, and adding it to the network.
 
 ## Submitter Development Workflow
 
@@ -7,7 +51,7 @@ This workflow creates a "houdini package", a JSON file which tells Houdini where
 1. Clone this repository somewhere on the machine you have Houdini installed on:
 
    ```sh
-   git clone git@github.com:casillas2/deadline-cloud-for-houdini.git
+   git clone git@github.com:aws-deadline/deadline-cloud-for-houdini.git
    cd deadline-cloud-for-houdini
    ```
 
@@ -21,7 +65,7 @@ This workflow creates a "houdini package", a JSON file which tells Houdini where
 
    ```sh
    cd ..
-   git clone git@github.com:casillas2/deadline-cloud.git
+   git clone git@github.com:aws-deadline/deadline-cloud.git
    cd deadline-cloud-for-houdini
    hatch run install --houdini-version X.Y --local-dep ../deadline-cloud
    ```

--- a/README.md
+++ b/README.md
@@ -1,61 +1,49 @@
+[![pypi](https://img.shields.io/pypi/v/deadline-cloud-for-houdini.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-houdini)
+[![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-houdini.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-houdini)
+[![license](https://img.shields.io/pypi/l/deadline-cloud-for-houdini.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/mainline/LICENSE)
+
 # AWS Deadline Cloud for Houdini
 
-This package has two active branches:
+AWS Deadline Cloud for Houdini is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within Houdini. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts Houdini's command line interface to support the [OpenJD specification][openjd].
 
-- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
-- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
-
-## Development
-
-See [DEVELOPMENT](DEVELOPMENT.md) for more information.
-
-## Build / Test / Release
-
-### Build the package
-
-```bash
-hatch build
-```
-
-### Run tests
-
-```bash
-hatch run test
-```
-
-### Run linting
-
-```bash
-hatch run lint
-```
-
-### Run formatting
-
-```bash
-hatch run fmt
-```
-
-## Run tests for all supported Python versions
-
-```bash
-hatch run all:test
-```
-
-## Use development Submitter in Houdini
-
-```bash
-hatch run install
-```
-
-A development version of the Deadline Cloud node is then available in `/out` by pressing TAB, typing `deadline`, and adding it to the network.
+[deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
+[deadline-cloud-client]: https://github.com/aws-deadline/deadline-cloud
+[openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki
+[openjd-adaptor-runtime]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+[openjd-adaptor-runtime-lifecycle]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/release/README.md#adaptor-lifecycle
 
 ## Compatibility
 
 This library requires:
 
+1. Houdini 19.5
 1. Python 3.9 or higher; and
-2. Linux, MacOS, or Windows operating system.
+1. Linux, MacOS, or Windows operating system.
 
+## Submitter
+
+This package provides a Houdini ROP node that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
+
+## Adaptor
+
+The Houdini Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Houdini and feed it commands. This gives the following benefits:
+* a standardized render application interface,
+* sticky rendering, where the application stays open between tasks,
+* path mapping, that enables cross-platform rendering
+
+Jobs created by the submitter use this adaptor by default.
+
+### Getting Started
+
+The adaptor can be installed by the standard python packaging mechanisms:
+```sh
+$ pip install deadline-cloud-for-houdini
+```
+
+After installation it can then be used as a command line tool:
+```sh
+$ houdini-openjd --help
+```
 ## Versioning
 
 This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
@@ -66,25 +54,13 @@ versions will increment during this initial development stage, they are describe
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
 
-## Downloading
-
-You can download this package from:
-- [GitHub releases](https://github.com/casillas2/deadline-cloud-for-houdini/releases)
-
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/release/CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## Telemetry
 
-This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
-
-You can opt out of telemetry data collection by either:
-
-1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
-2. Setting the config file: `deadline config set telemetry.opt_out true`
-
-Note that setting the environment variable supersedes the config file setting.
+See [telemetry](https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/release/docs/telemetry.md) for more information.
 
 ## License
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,10 @@
+# Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deadline-cloud-for-houdini"
+description = "The submitter and adaptor to enable Houdini support for AWS Deadline Cloud"
+authors = [
+  {name = "Amazon Web Services"},
+]
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.9"
-description = "The submitter and adaptor to enable Houdini support for AWS Deadline Cloud"
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are preparing for the first public release which includes publishing our distribution artifacts to PyPI. The description of the package on PyPI will include the README.md contents of this repository. Any links in the README.md that are relative need to be made absolute since they will not resolve correctly on PyPI. When choosing the absolute link, the link must refer to the correct branch (mainline vs release) depending on the context of the link.

Additionally, once the repository becomes public, visitors will be looking for basic information about the project such as:

- what is it?
- what can it be used for?
- how can it be used and operated?
- how can people interact with the project?
### What was the solution? (How)
- Wrote it in VSCode with .md rendering
- view in Github rendering
### What is the impact of this change?
Readers landing on our published PyPI and GitHub pages will have a more clear and curated introduction to the project, emphasizing why they might find it important and providing information to help them get started using it and contributing to it.
### How was this change tested?
- Using Visual Studio Code's markdown preview feature
- Reviewing GitHub's markdown rendered version
### Was this change documented?
This change is documentation :)
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*