### PR TITLE
chore: update homepage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "openjd-adaptor-runtime == 0.6.*",
 ]
 
+[project.urls]
+Homepage = "https://github.com/aws-deadline/deadline-cloud-for-houdini"
+Source = "https://github.com/aws-deadline/deadline-cloud-for-houdini"
+
 [project.scripts]
 houdini-openjd = "deadline.houdini_adaptor.HoudiniAdaptor:main"
 # The binary name 'HoudiniAdaptor' is deprecated.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Need to update the homepage for the package
### What was the solution? (How)
Added the links to the pyproject.toml
### What is the impact of this change?
People discovering the package on PyPI will be able to find the GitHub homepage for the package.
### How was this change tested?
It's a copy/paste from other repositories that we own and do the same.
### Was this change documented?
N/A
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*