### PR TITLE
fix: adaptor wheel override

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -253,16 +253,21 @@ def _get_parameter_values(node: hou.Node) -> dict[str, Any]:
     initial_status = node.parm("initial_status").evalAsString()
     failed_tasks_limit = node.parm("failed_tasks_limit").eval()
     task_retry_limit = node.parm("task_retry_limit").eval()
-    return {
-        "parameterValues": [
-            {"name": "deadline:priority", "value": priority},
-            {"name": "deadline:targetTaskRunStatus", "value": initial_status},
-            {"name": "deadline:maxFailedTasksCount", "value": failed_tasks_limit},
-            {"name": "deadline:maxRetriesPerTask", "value": task_retry_limit},
-            {"name": "HipFile", "value": _get_hip_file()},
-            *get_queue_parameter_values_as_openjd(node),
-        ]
-    }
+    parameter_values = [
+        {"name": "deadline:priority", "value": priority},
+        {"name": "deadline:targetTaskRunStatus", "value": initial_status},
+        {"name": "deadline:maxFailedTasksCount", "value": failed_tasks_limit},
+        {"name": "deadline:maxRetriesPerTask", "value": task_retry_limit},
+        {"name": "HipFile", "value": _get_hip_file()},
+        *get_queue_parameter_values_as_openjd(node),
+    ]
+
+    if node.parm("include_adaptor_wheels").eval():
+        parameter_values.append(
+            {"name": "AdaptorWheels", "value": node.parm("adaptor_wheels").evalAsString()}
+        )
+
+    return {"parameterValues": parameter_values}
 
 
 def _is_node_locked(rop_path: str) -> bool:
@@ -445,7 +450,6 @@ def _get_job_template(rop: hou.Node) -> dict[str, Any]:
             )
             with open(override_file) as yaml_file:
                 override_environment = yaml.safe_load(yaml_file)
-                override_environment["parameterDefinitions"][0]["default"] = str(adaptor_wheels)
                 job_template["parameterDefinitions"].extend(
                     override_environment["parameterDefinitions"]
                 )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The adaptor wheel override was broken by a [change](https://github.com/aws-deadline/deadline-cloud/pull/171) in `deadline-cloud` which made it so that PATH Job Parameter defaults can't be absolute paths. The way the adaptor wheel directory was being added to the template was by adding in a new job parameter with a default value of what was specified by the user. This would result in an error like below on submission:
```
Default PATH 'C:/Users/<USER>/deadlinecloud/deadline-cloud-for-houdini/wheels/' for parameter 'AdaptorWheels' is absolute.
PATH values must be relative, and must resolve within the Job Bundle directory.
```
### What was the solution? (How)
Remove the setting of the default value of the AdaptorWheel Job Parameter and instead set it when the other Job Parameters like the Hip File are set.
### What is the impact of this change?
The adaptor wheel override works again
### How was this change tested?
Tested with and without the adaptor wheel override set and verified in the jobs that were run that the adaptors were overridden or not.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*