### PR TITLE
fix: update SubmitJobProgressDialog to use storage_profile instead of storage_profile_id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.47.*",
+    "deadline == 0.48.*",
     "openjd-adaptor-runtime == 0.7.*",
 ]
 

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -643,6 +643,12 @@ def submit_callback(kwargs):
         queue_id = get_setting("defaults.queue_id")
         storage_profile_id = get_setting("settings.storage_profile_id")
 
+        storage_profile = None
+        if storage_profile_id:
+            storage_profile = api.get_storage_profile_for_queue(
+                farm_id, queue_id, storage_profile_id, deadline
+            )
+
         queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
 
         queue_role_session = api.get_queue_user_boto3_session(
@@ -663,7 +669,7 @@ def submit_callback(kwargs):
         job_progress_dialog.start_submission(
             farm_id,
             queue_id,
-            storage_profile_id,
+            storage_profile,
             job_bundle_dir,
             queue_parameters,
             asset_manager,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In `deadline-cloud` version 0.48, the `start_submission` method of the `SubmitJobProgressDialog` class now accepts `storage_profile` instead of `storage_profile_id`. This change is necessary to update the `deadline-cloud` dependency to version 0.48 and maintain compatibility with the latest version.

### What was the solution? (How)
Update to fetch storage profile and use it instead of `storage_profile_id` when calling the `start_submission` method of an instance of the `SubmitJobProgressDialog`.

### What is the impact of this change?
Maintains compatibility with the latest version

### How was this change tested?
Ran unit tests and ensured all passed.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*