### PR TITLE
fix: handle directories, references, and unnecessary files

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -51,13 +51,12 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
     asset_references.input_filenames.add(_get_hip_file())
 
     for parm, ref in hou.fileReferences():
-        if not parm:
-            continue
-        if parm.node() == rop_node:
-            continue
-        if ref.startswith(IGNORE_REF_VALUES):
-            continue
-        if parm.name() in IGNORE_REF_PARMS:
+        if (
+            (not parm)
+            or (parm.node() == rop_node)
+            or (ref.startswith(IGNORE_REF_VALUES))
+            or (parm.name() in IGNORE_REF_PARMS)
+        ):
             continue
 
         path = parm.evalAsString()

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -24,7 +24,7 @@ from ._version import version
 
 import hou
 
-IGNORE_REF_VALUES = ("opdef:", "oplib:", "temp:")
+IGNORE_REF_VALUES = ("opdef:", "oplib:", "temp:", "op:")
 IGNORE_REF_PARMS = (
     "taskgraphfile",
     "pdg_workingdir",
@@ -48,19 +48,24 @@ def _get_houdini_version() -> str:
 def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
     # collect input filenames
     asset_references = AssetReferences()
-    input_filenames: set[str] = set()
-    input_filenames.add(_get_hip_file())
+    asset_references.input_filenames.add(_get_hip_file())
+
     for parm, ref in hou.fileReferences():
-        if parm:
-            if parm.node() == rop_node:
-                continue
-            if ref.startswith(IGNORE_REF_VALUES):
-                continue
-            if parm.name() in IGNORE_REF_PARMS:
-                continue
-        if os.path.isdir(ref):
+        if not parm:
             continue
-        input_filenames.add(ref)
+        if parm.node() == rop_node:
+            continue
+        if ref.startswith(IGNORE_REF_VALUES):
+            continue
+        if parm.name() in IGNORE_REF_PARMS:
+            continue
+
+        path = parm.evalAsString()
+        if os.path.isdir(path):
+            asset_references.input_directories.add(path)
+        if os.path.isfile(path):
+            asset_references.input_filenames.add(path)
+
     rop_dir_map = {
         # Mantra/karma
         "Driver/ifd": "vm_picture",
@@ -84,19 +89,16 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
     }
     # collect output dirs for each ROP
     all_inputs = rop_node.inputAncestors()
-    output_directories: set[str] = set()
     for node in all_inputs:
         type_name = node.type().nameWithCategory()
         out_parm = rop_dir_map.get(type_name, None)
         if out_parm is not None:
             if callable(out_parm):
                 computed_dirs = out_parm(node)
-                output_directories.update(computed_dirs)
+                asset_references.output_directories.update(computed_dirs)
             else:
                 path = node.parm(out_parm).eval()
-                output_directories.add(os.path.dirname(path))
-    asset_references.input_filenames = input_filenames
-    asset_references.output_directories = output_directories
+                asset_references.output_directories.add(os.path.dirname(path))
     return asset_references
 
 

--- a/test/deadline_submitter_for_houdini/unit/test_assets.py
+++ b/test/deadline_submitter_for_houdini/unit/test_assets.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from unittest import mock
 from .mock_hou import hou_module as hou
 from deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter import (
     _get_scene_asset_references,
@@ -13,17 +14,38 @@ def test_get_scene_asset_references():
     )
     node = hou.node
     hou.node.type().name.return_value = "deadline-cloud"
-    parm = hou.Parm
+    temp_parm = hou.Parm
     hou.Parm.node.return_value = node
     hou.Parm.name.return_value = "shadowmap_file"
     hou.node.type().nameWithCategory.return_value = "Driver/ifd"
     hou.hipFile.path.return_value = "/some/path/test.hip"
     hou.node.parm().eval.return_value = "/tmp/foo.$F.exr"
+
+    dir_parm = mock.Mock()
+    dir_parm.node.return_value = None
+    dir_parm.evalAsString.return_value = "/path/assets/"
+
+    file_parm = mock.Mock()
+    file_parm.node.return_value = None
+    file_parm.evalAsString.return_value = "/path/asset.png"
+
     hou.fileReferences.return_value = (
-        (None, "$HIP/houdini19.5/otls/Deadline-Cloud.hda"),
-        (parm, "temp:$OS.rat"),
+        (dir_parm, "$HIP/houdini19.5/"),
+        (file_parm, "$HIP/houdini19.5/otls/Deadline-Cloud.hda"),
+        (temp_parm, "temp:$OS.rat"),
     )
-    a = _get_scene_asset_references(node)
-    assert a.input_filenames == {"$HIP/houdini19.5/otls/Deadline-Cloud.hda", "/some/path/test.hip"}
-    assert a.input_directories == set()
+    mock_os = mock.Mock()
+    mock_os.path.isdir = lambda path: path.endswith("/")
+    mock_os.path.isfile = lambda path: not path.endswith("/")
+
+    print(mock_os.path.isdir("a"))
+    print(mock_os.path.isdir("a/"))
+    with mock.patch(
+        "deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter.os", mock_os
+    ):
+        a = _get_scene_asset_references(node)
+
+    print(a)
+    assert a.input_filenames == {"/path/asset.png", "/some/path/test.hip"}
+    assert a.input_directories == {"/path/assets/"}
     assert a.output_directories == set()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There were several related bugs with automatically detecting and attaching files:
- https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/124
- https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/126
- https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/122

### What was the solution? (How)
When detecting if a parameter is a path or file, evaluate the parameter first to resolve the references and attach the expanded path. Also ignore `op:` data references which are [not files](https://www.sidefx.com/docs/houdini/io/op_syntax.html).

### What is the impact of this change?
Directories are detected. References in file and directory names are handled correctly. Data references are ignored. 

### How was this change tested?
Expanded unit tests. For manual testing, I created a file cache inside a geometry node and pointed the file cache to directories both with `$HIP` as part of the path and without it. I then opened the Deadline Cloud node and clicked "Parse files". The files and directories were correctly detected and attached.

### Was this change documented?
No documentation needed.

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*