### PR TITLE
fix: verify Deadline Cloud render node input exists before submitting

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -532,13 +532,23 @@ def save_bundle_callback(kwargs):
 
 def submit_callback(kwargs):
     node = kwargs["node"]
+    all_inputs = node.inputAncestors()
+
+    if not all_inputs:
+        # there are no inputs to the AWS Deadline Cloud render node
+        hou.ui.displayMessage(
+            "The AWS Deadline Cloud render node (ROP) must have an input ROP specified to submit a job",
+            title="Missing Input Render Node",
+            severity=hou.severityType.Warning,
+        )
+        return
+
     name = node.parm("name").evalAsString()
     # TODO: Populate from queue environment so that parameters can be overridden.
     queue_parameters: list[JobParameter] = []
     asset_references = _get_asset_references(node)
 
     # check for locked rops, Karma for example
-    all_inputs = node.inputAncestors()
     locked_rops = []
     for n in all_inputs:
         node_path = n.path()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If the Deadline Cloud ROP does not have an input ROP, then submission of a job will first hash and upload all the files for the job, then attempt to submit the job, then get a confusing error message related to missing steps.

### What was the solution? (How)
The error is caused by missing an input ROP, but the the message is confusing. Added verification that there is an input ROP at the start of the submission.

### What is the impact of this change?
Easier onboarding for customers

### How was this change tested?
1. Created a simple render with spheres, light, and camera
2. Created a Mantra ROP
3. Created a Deadline Cloud ROP, but did not connect it to the Mantra ROP
4. Click "Submit" in the Deadline ROP

Before:
![image](https://github.com/aws-deadline/deadline-cloud-for-houdini/assets/127782171/c5dae461-afff-44df-9ea4-921cb4da5433)

After:
![image](https://github.com/aws-deadline/deadline-cloud-for-houdini/assets/127782171/723ed942-3c5a-42e1-a500-1cb6960ee0dc)


### Was this change documented?
No, not necessary

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*