### PR TITLE
chore: support more dependency parser cases

### DIFF
--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -31,24 +31,15 @@ def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
 
 
 class Dependency:
+    pip_requirement: str
     name: str
-    operator: Optional[str]
-    version: Optional[str]
 
     def __init__(self, dep: str):
-        components = dep.split(" ")
-        self.name = components[0]
-        if len(components) > 2:
-            self.operator = components[1]
-            self.version = components[2]
-        else:
-            self.operator = None
-            self.version = None
+        self.pip_requirement = dep.strip().split(";", maxsplit=1)[0].replace(" ", "")
+        self.name = dep.strip().split(" ", maxsplit=1)[0]
 
     def for_pip(self) -> str:
-        if self.operator is not None and self.version is not None:
-            return f"{self.name}{self.operator}{self.version}"
-        return self.name
+        return self.pip_requirement
 
     def __repr__(self) -> str:
         return self.for_pip()

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -102,6 +102,7 @@ def _resolve_dependencies(local_deps: list[Path]) -> dict[str, str]:
         "--json",
         *[dep.for_pip() for dep in flattened_dependency_list],
     ]
+    print(f"Running: {' '.join(args)}")
     result = subprocess.run(args, check=True, capture_output=True, text=True)
     return json.loads(result.stdout)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Running the command `hatch run install --houdini-version 19.5 --local-dep ..\deadline-cloud` resulted in an error

### What was the solution? (How)
The error was caused by a new format of dependency ` "typing_extensions >= 4.7,< 4.12; python_version == '3.7'"` in the `deadline-cloud` repository ([code link](https://github.com/aws-deadline/deadline-cloud/blob/23fcbdf04651408d4de6d0e0472a62207c50dec8/pyproject.toml#L42), [PR](https://github.com/aws-deadline/deadline-cloud/pull/289/files)). It is possible that dependencies need upper bounds due to breaking changes or security vulnerabilities, so we should support it in our scripts. 

### What is the impact of this change?
`--local-dep` option works again, allowing use of local dependencies during development

### How was this change tested?
`hatch run install --houdini-version 19.5 --local-dep ..\deadline-cloud` succeeds

### Was this change documented?
No, not necessary

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*