### PR TITLE
fix: pass through log verbosity

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -39,39 +39,58 @@ class HoudiniHandler:
 
     def set_node_settings(self, node):
         # this is a place holder function
-        # TODO remove after commom node library implemented
+        # TODO remove after common node library implemented
 
         node_type = node.type().nameWithCategory().split("/")
-        if node_type[0] == "Driver":
-            if node_type[1] == "ifd":
-                # mantra render node
-                alfredProgress = node.parm("vm_alfprogress")
-                if alfredProgress is not None:
-                    alfredProgress.set(1)
-                    print("Enabled Alfred style progress")
 
-                verbosity = node.parm("vm_verbose")
-                if verbosity is not None:
-                    verbosity.set(3)
-                    print("Set verbosity to 3")
+        if node_type[0] != "Driver":
+            return
 
-            elif node_type[1] == "karma":
-                alfredProgress = node.parm("alfprogress")
-                if alfredProgress is not None:
-                    alfredProgress.set(1)
-                    print("Enabled Alfred style progress")
-                verbosity = node.parm("verbosity")
-                if verbosity is not None:
+        if len(node_type) < 2:
+            return
+
+        if node_type[1] == "ifd":
+            # Mantra render node
+            alfredProgress = node.parm("vm_alfprogress")
+            if alfredProgress is not None:
+                alfredProgress.set(1)
+                print("Enabled Alfred style progress")
+            verbosity = node.parm("vm_verbose")
+            if verbosity is not None:
+                # Mantra verbosity is an int with range 0 to 5
+                if isinstance(verbosity.eval(), int) and verbosity.eval() < 2:
+                    # 2 provides basic logging, we set it as a minimum to help with debugging issues
+                    verbosity.set(2)
+                    if verbosity.eval() == 2:
+                        # The verbosity won't be changed if the parameter is "keyed", so we check the value before
+                        # logging that it was increased
+                        # https://www.sidefx.com/docs/houdini/network/parms.html#color
+                        print("Increased verbosity to 2 to include basic logging")
+                print(f"Logging verbosity is set to {verbosity.eval()}")
+            return
+
+        if node_type[1] == "usdrender":
+            # Karma render node
+            alfredProgress = node.parm("alfprogress")
+            if alfredProgress is not None:
+                alfredProgress.set(1)
+                print("Enabled Alfred style progress")
+            verbosity = node.parm("verbosity")
+            if verbosity is not None:
+                # Karma verbosity is a str with options "", "3", "9", "9p", "9P"
+                # 3 means "Rendering Statistics", we set it as a minimum to help with debugging issues
+                if isinstance(verbosity.eval(), str) and verbosity.eval() == "":
                     verbosity.set("3")
-                    hou.logging.setRenderLogVerbosity(3)
-                    print("Set verbosity to 3")
-
-        else:
-            pass
+                    if verbosity.eval() == "3":
+                        # The verbosity won't be changed if the parameter is "keyed", so we check the value before
+                        # logging that it was increased
+                        # https://www.sidefx.com/docs/houdini/network/parms.html#color
+                        print("Increased verbosity to '3' to include basic logging")
+                print(f"Logging verbosity is set to '{verbosity.eval()}'")
 
     def start_render(self, data: dict) -> None:
         """
-        Uses active node and calls hou's render, currently hardcoded to rendering a single fram
+        Uses active node and calls hou's render, currently hardcoded to rendering a single frame
 
         Args:
             data (dict):

--- a/test/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py
@@ -505,7 +505,10 @@ class TestHoudiniAdaptor_on_cleanup:
         assert regex_callbacks is adaptor._regex_callbacks
 
     @patch("deadline.houdini_adaptor.HoudiniAdaptor.adaptor.HoudiniAdaptor.update_status")
-    def test_handle_complete(self, mock_update_status: Mock, init_data: dict):
+    @patch.object(HoudiniAdaptor, "_is_rendering", new_callable=PropertyMock(return_value=True))
+    def test_handle_complete(
+        self, mock_is_rendering: Mock, mock_update_status: Mock, init_data: dict
+    ):
         """Tests that the _handle_complete method updates the progress correctly"""
         # GIVEN
         adaptor = HoudiniAdaptor(init_data)


### PR DESCRIPTION
Resolves https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/120

### What was the problem/requirement? (What/Why)
The logging verbosity for Mantra and Karma renders can be configured through the Mantra or Karma node and this is passed through to the Deadline Cloud render.

### What was the solution? (How)
Currently, this value is hardcoded to 3. Removing this code passes through the log verbosity specified in the Mantra or Karma node.

Also noted that Karma was incorrectly labeled as having a node type "Driver/karma" rather than "Driver/usdrender", so updated that everywhere.

### What is the impact of this change?
Log verbosity can be specified in Deadline Cloud renders, and progress is output by default in Karma for easier tracking.

### How was this change tested?
1. Created a simple scene with geometry, light, and camera
2. Created a Mantra node and Deadline Cloud node, connected the Mantra node output to the Deadline Cloud node input
3. Adjusted the Mantra log verbosity under Rendering > Statistics >Verbose Level
4. Submitted renders with different verbosity levels and confirmed that verbosity of logs changed accordingly
5. Created a Karma node and unlocked it
6. Introspected into the Karma node and adjusted the USD Render node > Husk > Statistics > Verbosity
7. Submitted renders with different verbosity levels and confirmed that verbosity of logs changed accordingly

### Was this change documented?
No, not required

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*