### PR TITLE
chore: migrate HTTPClientInterface -> ClientInterface

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_client.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_client.py
@@ -10,12 +10,12 @@ from typing import Optional
 # so that importing just the adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import (  # type: ignore[import]
-        HTTPClientInterface,
+        ClientInterface,
     )
     from houdini_adaptor.HoudiniClient.houdini_handler import HoudiniHandler  # type: ignore[import]
 except ImportError:
     from openjd.adaptor_runtime_client import (
-        HTTPClientInterface,
+        ClientInterface,
     )
     from deadline.houdini_adaptor.HoudiniClient.houdini_handler import HoudiniHandler
 
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
     raise OSError("Could not find the Houdini module. Are you running this inside of Houdini?")
 
 
-class HoudiniClient(HTTPClientInterface):
+class HoudiniClient(ClientInterface):
     """
     Client that runs in Houdini for the Houdini Adaptor
     """

--- a/test/deadline_adaptor_for_houdini/unit/HoudiniClient/test_client.py
+++ b/test/deadline_adaptor_for_houdini/unit/HoudiniClient/test_client.py
@@ -12,8 +12,8 @@ from deadline.houdini_adaptor.HoudiniClient.houdini_client import HoudiniClient,
 
 
 class TestHoudiniClient:
-    @patch("deadline.houdini_adaptor.HoudiniClient.houdini_client.HTTPClientInterface")
-    def test_houdiniclient(self, mock_httpclient: Mock) -> None:
+    @patch("deadline.houdini_adaptor.HoudiniClient.houdini_client.ClientInterface")
+    def test_houdiniclient(self, mock_client_interface: Mock) -> None:
         """Tests that the houdini client can initialize, set a renderer and close"""
         client = HoudiniClient(server_path=str(9999))
         client.close()
@@ -21,8 +21,8 @@ class TestHoudiniClient:
     @patch("deadline.houdini_adaptor.HoudiniClient.houdini_client.os.path.exists")
     @patch.dict(os.environ, {"HOUDINI_ADAPTOR_SERVER_PATH": "server_path"})
     @patch("deadline.houdini_adaptor.HoudiniClient.HoudiniClient.poll")
-    @patch("deadline.houdini_adaptor.HoudiniClient.houdini_client.HTTPClientInterface")
-    def test_main(self, mock_httpclient: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
+    @patch("deadline.houdini_adaptor.HoudiniClient.houdini_client.ClientInterface")
+    def test_main(self, mock_client_interface: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
         """Tests that the main method starts the houdini client polling method"""
         # GIVEN
         mock_exists.return_value = True


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`hatch run test` was failing on Windows. The error message was on a missing import of `HttpClientInterface` from the OpenJD adapter runtime client.

### What was the solution? (How)
The client interface had been created for Windows in https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/33, but Houdini wasn't migrated over to it yet. Migrated it :)

`hatch run test` now passes on Windows

### What is the impact of this change?
Ability to run tests locally

### How was this change tested?
`hatch run test`

### Was this change documented?
No, not required

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*