### PR TITLE
chore: add windows and py312 to CIs

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,8 +14,8 @@ jobs:
     name: Python
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We recently fixed some tests to make them pass on Windows, so we can add them to the CI!

### What was the solution? (How)

Added windows latest to the code quality checks. Also added py312 to the CIs at the same time.

### What is the impact of this change?

More confidence our code works cross-platform and with newer python versions!

### How was this change tested?

By running the code quality checks in this PR

### Was this change documented?

N/A

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*