### PR TITLE
fix: improve error messages when farm or queue ID not defined

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -528,13 +528,29 @@ def submit_callback(kwargs):
                 "houdini-version": _get_houdini_version(),
             }
         )
+        farm_id = get_setting("defaults.farm_id")
+        if not farm_id:
+            hou.ui.displayMessage(
+                "Please configure the farm ID in the AWS Deadline Cloud render node (ROP) settings",
+                title="Farm ID Required",
+                severity=hou.severityType.Warning,
+            )
+            return
+
+        queue_id = get_setting("defaults.queue_id")
+        if not queue_id:
+            hou.ui.displayMessage(
+                "Please configure the queue ID in the AWS Deadline Cloud render node (ROP) settings",
+                title="Queue ID Required",
+                severity=hou.severityType.Warning,
+            )
+            return
+
         deadline = api.get_boto3_client("deadline")
 
         job_bundle_dir = create_job_history_bundle_dir("houdini", name)
         _create_job_bundle(node, job_bundle_dir, asset_references)
 
-        farm_id = get_setting("defaults.farm_id")
-        queue_id = get_setting("defaults.queue_id")
         storage_profile_id = get_setting("settings.storage_profile_id")
 
         storage_profile = None


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When first submitting a job to AWS Deadline Cloud using its render node, I received unexpected error messages with an Access Denied error. These were related to missing default farms and queues.

![image](https://github.com/aws-deadline/deadline-cloud-for-houdini/assets/127782171/c508a213-fb87-473d-b678-22df280e4629)

### What was the solution? (How)
Added a check whether the farm and queue are defined before calling GetQueue in the submitter.

![image](https://github.com/aws-deadline/deadline-cloud-for-houdini/assets/127782171/cdbe6ed3-e95a-4d34-af16-bc8560334771)

![image](https://github.com/aws-deadline/deadline-cloud-for-houdini/assets/127782171/9f4c7450-80ea-48ba-bd6b-6b71d778f338)

### What is the impact of this change?
Easier onboarding for new customers

### How was this change tested?
1. Created a simple scene with geometry, light, camera
2. Connected a Karma ROP to the Deadline Cloud ROP
3. Clicked submit (without adding settings, or after clearing the default farm and queue with `deadline config set defaults.farm_id ""` and `deadline config set defaults.queue_id ""`)

### Was this change documented?
No, not required

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*