### PR TITLE
test: add output directory unit tests

### DIFF
--- a/test/deadline_submitter_for_houdini/unit/test_assets.py
+++ b/test/deadline_submitter_for_houdini/unit/test_assets.py
@@ -1,10 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import pytest
 from unittest import mock
 from .mock_hou import hou_module as hou
 from deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets import (
     _get_scene_asset_references,
+    _get_output_directories,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_hou_mocks():
+    for each in [d for d in dir(hou) if not d.startswith("__")]:
+        attr = getattr(hou, each)
+        if hasattr(attr, "reset_mock"):
+            attr.reset_mock()
+        else:
+            del attr
 
 
 def test_get_scene_asset_references():
@@ -51,3 +63,40 @@ def test_get_scene_asset_references():
     assert asset_refs.input_filenames == {"/path/asset.png", "/some/path/test.hip"}
     assert asset_refs.input_directories == {"/path/assets/"}
     assert asset_refs.output_directories == set()
+
+
+def test_get_output_directories():
+    """
+    Test that given a node, the type name and category are mapped correctly to
+    determine the parm to get the output directory from and return it.
+    """
+    node = hou.node
+    node.type().nameWithCategory.return_value = "Driver/geometry"
+    node.parm().eval.return_value = "/test/directory/detection/output.png"
+
+    output_directories = _get_output_directories(node)
+
+    node.parm.assert_called_with("sopoutput")
+    assert output_directories == {"/test/directory/detection"}
+
+
+@pytest.mark.parametrize(
+    ("node_type", "output_parm_name"), [("Driver/fetch", "source"), ("Driver/wedge", "driver")]
+)
+def test_get_recursive_output_directories(node_type: str, output_parm_name: str):
+    """
+    Test output directory detection for fetch and wedge nodes that recursively
+    find the output directories.
+    """
+    inner_node = mock.MagicMock()
+    inner_node.type().nameWithCategory.return_value = "Driver/ifd"
+    inner_node.parm().eval.return_value = "/test/output/directory/mantra/test.png"
+    node = hou.node
+    node.type().nameWithCategory.return_value = node_type
+    node.node.return_value = inner_node
+
+    out_dirs = _get_output_directories(node)
+
+    node.parm.assert_called_once_with(output_parm_name)
+    inner_node.parm.assert_called_with("vm_picture")
+    assert out_dirs == {"/test/output/directory/mantra"}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The output directory detection was improved in a prior PR(#144), but no unit tests were added for the new logic.
### What was the solution? (How)
Adding some tests for output directory detection
### What is the impact of this change?
Better tests
### How was this change tested?
By running the tests locally
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*