### PR TITLE
chore: bump min test coverage to 60%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ source =  [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 48
+fail_under = 60
 
 [tool.semantic_release]
 # Can be removed or set to true once we are v1


### PR DESCRIPTION
Bumping the minimum unit test coverage to 60% because we have added several tests recently, and we want to ensure that we have automated tests of new code. Current coverage is 62.86%

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*