### PR TITLE
doc: add FAQ, including how to fail immediately if textures are missing

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,9 @@
+## How can I fail Mantra renders immediately if textures are missing?
+
+There is a hidden feature in Mantra that can be used to fail the render immediately if textures are missing. To activate it:
+1. Right click the Mantra node and go to "Parameters and channels" > "Edit Parameter interface"
+2. In the "Create Parameters" section, select "Render Properties" and filter for "vm_abort_missing_texture"
+3. Right click "Abort on missing texture (vm_abort_missing_texture)" and click "Install Parameter"
+4. Click "Accept"
+5. Left click the Mantra node and navigate to "Rendering" > "Render"
+6. Select the "Abort on missing texture" checkbox


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A customer was confused about how to fail a render immediately if textures were missing (a cost/time-saving measure)

### What was the solution? (How)
Added documentation about how to do so using Houdini's built-in options.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*