### PR TITLE
fix: correct typo in render strategy docs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,7 +10,7 @@ By default, if a node is a geometry node with the "Initialize Simulation OPs" op
 
 ### Overriding the render strategy
 
-You can override the render strategy be creating a `deadline_cloud_render_strategy` parameter with a value of either `SEQUENTIAL` or `PARALLEL`.
+You can override the render strategy by creating a `deadline_cloud_render_strategy` parameter on your render node (e.g. Mantra or Karma) with a value of either `SEQUENTIAL` or `PARALLEL`.
 
 To add a parameter to a node:
 1. Right click a node in the `out` context, select "Parameters and Channels" then click "Edit Parameter Interface".


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There was a typo in the render strategy docs, and an opportunity for clarification.

### What was the solution? (How)
Fix and tweak the docs.

### What is the impact of this change?
The user guide is improved.

### How was this change tested?
n/a

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*