### PR TITLE
feat: capture files with time-based variables for job attachments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ source =  [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 60
+fail_under = 65
 
 [tool.semantic_release]
 # Can be removed or set to true once we are v1

--- a/test/deadline_submitter_for_houdini/unit/test_assets.py
+++ b/test/deadline_submitter_for_houdini/unit/test_assets.py
@@ -1,11 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from pathlib import Path
+from unittest import mock
 
 import pytest
-from unittest import mock
+from pytest import param
+
 from .mock_hou import hou_module as hou
 from deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets import (
+    _get_asset_references,
     _get_scene_asset_references,
     _get_output_directories,
+    _houdini_time_vars_to_glob,
     _parse_files,
 )
 from deadline.client.job_bundle.submission import AssetReferences
@@ -27,10 +32,12 @@ def test_get_scene_asset_references():
 
     dir_parm = mock.Mock()
     dir_parm.node.return_value = None
+    dir_parm.unexpandedString.return_value = "/path/assets/"
     dir_parm.evalAsString.return_value = "/path/assets/"
 
     file_parm = mock.Mock()
     file_parm.node.return_value = None
+    file_parm.unexpandedString.return_value = "/path/asset.png"
     file_parm.evalAsString.return_value = "/path/asset.png"
 
     hou.fileReferences.return_value = (
@@ -212,3 +219,254 @@ def test_parse_files_manually_added(
             ]
         )
         assert mock_update_paths_parm.call_count == 6
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        param("a.$F.png", "a.*.png", id="$F"),
+        param("b.${F}.png", "b.*.png", id="${F}"),
+        param("c.$F4.png", "c.*.png", id="$F4"),
+        param("d.${F4}.png", "d.*.png", id="${F4}"),
+        param("e.$FF.png", "e.*.png", id="$FF"),
+        param("f.${FF}.png", "f.*.png", id="${FF}"),
+        param("g.$T.png", "g.*.png", id="$T"),
+        param("h.${T}.png", "h.*.png", id="${T}"),
+        param("i.$SF.png", "i.*.png", id="$SF"),
+        param("j.${SF}.png", "j.*.png", id="${SF}"),
+        param("k.$ST.png", "k.*.png", id="$ST"),
+        param("l.${ST}.png", "l.*.png", id="{ST}"),
+        param("$HIPNAME.$OS.png", "$HIPNAME.$OS.png", id="No matches"),
+        param("$HIPNAME.$OS.$F4.png", "$HIPNAME.$OS.*.png", id="Only time variable matched"),
+        param("$HIP/$HIPNAME.$OS.png", "$HIP/$HIPNAME.$OS.png", id="No matches with directories"),
+        param(
+            "$HIP/$HIPNAME.$OS.$F4.png",
+            "$HIP/$HIPNAME.$OS.*.png",
+            id="Only time variable matched with directories",
+        ),
+    ],
+)
+def test_time_variable_pattern_matching(input, expected):
+    """Test to ensure we only replace the time-based variables and ignore others"""
+    # GIVEN / WHEN
+    actual = _houdini_time_vars_to_glob(input)
+
+    # THEN
+    assert actual == expected
+
+
+# "pattern", "filenames"
+filenames_with_frames = [
+    param(
+        "sequence.$F.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="$F",
+    ),
+    param(
+        "sequence.${F}.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="Protected $F",
+    ),
+    param(
+        "sequence.$F4.png",
+        ["sequence.0000.png", "sequence.0001.png", "sequence.0002.png"],
+        id="$F with padding",
+    ),
+    param(
+        "sequence.${F4}.png",
+        ["sequence.0000.png", "sequence.0001.png", "sequence.0002.png"],
+        id="Protected $F with padding",
+    ),
+    param(
+        "sequence.$F4.$F5.png",
+        [
+            "sequence.000.0000.png",
+            "sequence.0001.00001.png",
+        ],
+        id="Multiple $F with padding",
+    ),
+    param(
+        "sequence.${F}F.png",
+        [
+            "sequence.0F.png",
+            "sequence.1F.png",
+        ],
+        id="Protected $F with trailing F",
+    ),
+    param(
+        "sequence.${F4}F.png",
+        [
+            "sequence.0000F.png",
+            "sequence.0001F.png",
+        ],
+        id="Protected $F with padding and trailing F",
+    ),
+    param(
+        "sequence.$FF.png",
+        [
+            "sequence.0.png",
+            "sequence.01.png",
+        ],
+        id="$FF",
+    ),
+    param(
+        "sequence.${FF}.png",
+        [
+            "sequence.0.png",
+            "sequence.01.png",
+        ],
+        id="Protected $FF",
+    ),
+    param(
+        "sequence.$FFF.png",
+        [
+            "sequence.0F.png",
+            "sequence.1F.png",
+        ],
+        id="$FF with trailing F",
+    ),
+    param(
+        "sequence.$SF.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="$SF",
+    ),
+    param(
+        "sequence.${SF}.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="Protected $SF",
+    ),
+    param(
+        "sequence.$ST.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="$ST",
+    ),
+    param(
+        "sequence.${ST}.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="Protected $ST",
+    ),
+    param(
+        "sequence.`python stuff`.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="Python expression",
+    ),
+    param(
+        "sequence.`$F5`.png",
+        [
+            "sequence.0.png",
+            "sequence.1.png",
+        ],
+        id="Python expression with a frame variable within",
+    ),
+]
+
+
+@pytest.mark.parametrize(("pattern", "filenames"), filenames_with_frames)
+def test_filenames_with_frames(tmpdir, pattern: str, filenames: list[str]):
+    """Tests that we actually capture filenames that contain a time-based variable."""
+    # GIVEN
+    tmpdir_path = Path(tmpdir)
+    filesystem = {str(tmpdir_path / file) for file in filenames}
+    extra_files = {
+        "seq.0.png",
+        "sequence.1.jpg",
+        "sequence.png",
+    }
+
+    # create files on disc
+    for file in filesystem | extra_files:
+        (tmpdir_path / file).touch()
+
+    # populate houdini node with paths
+    mock_ = mock.Mock()
+    mock_.eval.return_value = str(tmpdir_path / _houdini_time_vars_to_glob(pattern))
+    mock_.unexpandedString.return_value = str(tmpdir_path / pattern)
+    mocked_input_parms: list = [mock_]
+
+    def input_filenames_override(str_):
+        mock_ = mock.Mock()
+        if str_ != "input_filenames":
+            mock_.multiParmInstances.return_value = []
+            return mock_
+
+        mock_.multiParmInstances.return_value = mocked_input_parms
+        return mock_
+
+    node = hou.node
+    node.parm.side_effect = input_filenames_override
+
+    # WHEN
+    result_refs = _get_asset_references(node)
+
+    # THEN
+    assert result_refs.input_filenames == filesystem
+    assert len(result_refs.input_filenames) == len(filesystem)
+
+
+def test_dirs_with_time_variable(tmpdir):
+    """Tests that we actually capture file paths whose directory
+    contain a time-based variable."""
+    # GIVEN
+    pattern = Path("show", "$F", "shot.png")
+    matched_paths = [
+        Path("show", "0", "shot.png"),
+        Path("show", "1", "shot.png"),
+        Path("show", "2", "shot.png"),
+    ]
+    not_matched_paths = [
+        Path("show", "0", "noshot.png"),
+    ]
+    tmpdir_path = Path(tmpdir)
+    matched_filesystem = {str(tmpdir_path / path) for path in matched_paths}
+    filesystem = {str(tmpdir_path / path) for path in matched_paths + not_matched_paths}
+    # create files on disc
+    for file in filesystem:
+        (tmpdir_path / file).parent.mkdir(parents=True, exist_ok=True)
+        (tmpdir_path / file).touch()
+
+    # populate houdini node with paths
+    mock_ = mock.Mock()
+    mock_.eval.return_value = str(tmpdir_path / _houdini_time_vars_to_glob(str(pattern)))
+    mock_.unexpandedString.return_value = str(tmpdir_path / pattern)
+    mocked_input_parms: list = [mock_]
+
+    def input_filenames_override(str_):
+        mock_ = mock.Mock()
+        if str_ != "input_filenames":
+            mock_.multiParmInstances.return_value = []
+            return mock_
+
+        mock_.multiParmInstances.return_value = mocked_input_parms
+        return mock_
+
+    node = hou.node
+    node.parm.side_effect = input_filenames_override
+
+    # WHEN
+    result_refs = _get_asset_references(node)
+
+    # THEN
+    assert filesystem != matched_filesystem
+    assert result_refs.input_filenames == matched_filesystem
+    assert len(result_refs.input_filenames) == len(matched_filesystem)


### PR DESCRIPTION
Resolves #125 

### What was the problem/requirement? (What/Why)

The deadliine-cloud rop node was evaluating parms at the current frame. So any filepaths that contained time-based variables would only have 1 of those files captured rather than the whole sequence

### What was the solution? (How)

There were a few solutions available, each with various downsides.

1. Evaluate the parm with evalAsStringAtFrame`, would require us to figure out all the relevant frame numbers and adjust for offsets.
    * this requires us to get it perfectly correct - which is definitely higher effort

2. Grab the directory before the frame variable
    * anecdotal evidence seems to indicate frames are mostly in the file name, but users are not restricted to having them in directories. So automatically uploading whole directories without insight as to why they're added leads to the potential of a lot of extraneous files uploaded. 

3. Replace the relevant variables with globs and and let the stdlib take care of finding them.

I went with replacing the time-based variables for input filenames with globs to allow us to do some naive pattern matching. The code itself is then pretty simple with avenues to improve it later.
* Downside here is there may be inadvertent files that get included because they match the glob pattern and not the time variable. Future improvement could be to filter out files that matched the globs but not the pattern
* Input directories are being ignored in this change, since the solution can be equivalent to going up a directory, which can be pretty dangerous while multiple levels of directories down from frames seem like a pretty rare case.

### What is the impact of this change?

We get a LOT more of the files users want to be included with the job!

### How was this change tested?

Added a bunch of unit tests to capture the pattern replacement and globbing functionality. 

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

Test coverage is now at ~67%
```
Required test coverage of 65.0% reached. Total coverage: 67.59%
```

I'll need to retest the node within Houdini again after some rebasing.

### Was this change documented?

N/A

### Is this a breaking change?

Fixing!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*