### PR TITLE
feat: add 20.0 and 20.5 dev installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AWS Deadline Cloud for Houdini is a python package that allows users to create [
 
 This library requires:
 
-1. Houdini 19.5
+1. Houdini 19.5, 20.0 or 20.5
 1. Python 3.9 or higher; and
 1. Linux, MacOS, or Windows operating system.
 

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -26,9 +26,7 @@ class HoudiniVersion:
 
     VERSION_REGEX = re.compile(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?")
 
-    PYTHON_VERSIONS = {
-        "19.5": "3.9",
-    }
+    PYTHON_VERSIONS = {"19.5": "3.9", "20.0": "3.10", "20.5": "3.11"}
 
     def __init__(self, arg_version: Optional[str] = None):
         version = self._get_houdini_version(arg_version)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Dev install only worked for Houdini 19.5
### What was the solution? (How)
Added the python mappings for 20.0 and 20.5
### What is the impact of this change?
Users can do a dev install of the submitter into Houdini 20.0 and 20.5
### How was this change tested?
Did a dev install on Windows/Mac/Linux(RHEL9) for Houdini 20.0 and 20.5 and validated that submissions worked.
### Was this change documented?
Updated the README compatibility section
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*