### PR TITLE
docs: add FAQ link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ After installation it can then be used as a command line tool:
 ```sh
 $ houdini-openjd --help
 ```
+
+## Frequently Asked Questions
+See our [FAQ](https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/release/docs/FAQ.md) for a list of frequently asked questions.
+
 ## Versioning
 
 This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
FAQ was hard to find
### What was the solution? (How)
Link the FAQ from the README
### What is the impact of this change?
Users are more likely to see our FAQ before cutting issues
### How was this change tested?
N/A
### Was this change documented?
Is a docs change
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*