### PR TITLE
chore(deps): revert Update python-semantic-release requirement (#172)"

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 9.10.*
+python-semantic-release == 9.9.*


### PR DESCRIPTION
This reverts commit fc791d13367922e8ccb5e256492829c1eed1370a.

### What was the problem/requirement? (What/Why)
The update to 9.10.* broke the CHANGELOG update for the latest release.
### What was the solution? (How)
Revert to 9.9.* until we can figure out what in the latest release is messing with the CHANGELOG generation
### What is the impact of this change?
deadline-cloud-for-houdini can be released properly
### How was this change tested?
Verified in a dev setup that the previous minor version resulted in the correct CHANGELOG
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*