### PR TITLE
fix: add deadline cloud soho script

### DIFF
--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/DialogScript
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/DialogScript
@@ -560,6 +560,20 @@
         label   "Render with Take"
         export  none
     }
+    parm {
+        name    "soho_program"
+        label   "SOHO program"
+        type    string
+        invisible
+        default { "deadline_cloud_soho.py" }
+    }
+    parm {
+        name    "soho_outputmode"
+        label   "SOHO output mode"
+        type    integer
+        invisible
+        default { "2" }
+    }
     group {
         name    "job_settings"
         label   "Shared Job Settings"

--- a/src/deadline/houdini_submitter/soho/deadline_cloud_soho.py
+++ b/src/deadline/houdini_submitter/soho/deadline_cloud_soho.py
@@ -1,0 +1,7 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import hou
+
+hou.ui.displayMessage(
+    "Please use the 'Submit' button within the Deadline Cloud node to render with AWS Deadline Cloud."
+)


### PR DESCRIPTION
Fixes: #168 

### What was the problem/requirement? (What/Why)
When the render button was clicked on the Deadline Cloud node the user would get a notification that no soho script was found.
### What was the solution? (How)
Add a [soho script](https://www.sidefx.com/docs/houdini/render/soho.html) and set it up to be run when the render button is clicked on the Deadline Cloud node. The script will display a message to the user that to render with the Deadline Cloud node they should click the submit button within the node instead of clicking render on it.

![image](https://github.com/user-attachments/assets/92086742-03e0-4773-a2d5-44aca1aecf33)

### What is the impact of this change?
Hopefully less confusion on how to render with the Deadline Cloud node.
### How was this change tested?
Made an empty scene with just a Deadline Cloud node and clicked render to verify that the "no soho script" error would show. Then made my changes and verified a new popup appeared that pointed me towards pressing the submit button in the node itself.

- Have you run the unit tests?
Yes

### Was this change documented?

It will be documented as closing issue 168

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
