### PR TITLE
fix(installer): fix installer system installs

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -1,7 +1,7 @@
 <componentGroup>
     <name>deadline_cloud_for_houdini</name>
-    <description>Deadline Cloud for Houdini</description>
-    <detailedDescription>Houdini plugin for submitting jobs to AWS Deadline Cloud. Compatible with Houdini 19.5, 20.0 and 20.5</detailedDescription>
+    <description>Deadline Cloud for Houdini 19.5-20.5</description>
+    <detailedDescription>Houdini plugin for submitting jobs to AWS Deadline Cloud. Compatible with Houdini 19.5-20.5</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -19,7 +19,7 @@
         </folder>
         <folder>
             <description>Package</description>
-            <destination>${installdir}/tmp/packages</destination>
+            <destination>${houdini_packagedir}/</destination>
             <name>houdinipackage</name>
             <platforms>all</platforms>
             <distributionFileList>
@@ -30,13 +30,20 @@
             <actionList>
                 <setInstallerVariable name="deadline_package_file_name" value="deadline_submitter_for_houdini.json" />
                 <substitute>
-                    <files>${installdir}/tmp/packages/${deadline_package_file_name}</files>
+                    <files>${houdini_packagedir}/${deadline_package_file_name}</files>
                     <type>exact</type>
                     <encoding>utf-8</encoding>
                     <substitutionList>
                         <substitution pattern="INSTALL_DIR_PLACEHOLDER" value="${installdir.unix}" />
                     </substitutionList>
                 </substitute>
+                <fnAddPathEnvironmentVariable>
+                    <progressText>Setting HOUDINI_PACKAGE_DIR</progressText>
+                    <name>HOUDINI_PACKAGE_DIR</name>
+                    <value>${houdini_packagedir}</value>
+                    <scope>${installscope}</scope>
+                    <insertAt>end</insertAt>
+                </fnAddPathEnvironmentVariable>
             </actionList>
         </folder>
         <folder>
@@ -51,57 +58,12 @@
             </distributionFileList>
         </folder>
     </folderList>
-    <functionDefinitionList>
-        <actionDefinition name="fnCopyHoudiniPackageFile">
-            <parameterList>
-                <stringParameter name="houdiniVersion"/>
-                <stringParameter name="houdiniPackageDir"/>
-                <stringParameter name="packageName" default="${deadline_package_file_name}"/>
-            </parameterList>
-            <actionList>
-                <setInstallerVariable name="packagesDir" value="${houdiniPackageDir}${houdiniVersion}/packages" />
-                <createDirectory>
-                    <path>${packagesDir}</path>
-                    <ruleList>
-                        <fileExists path="${packagesDir}" negate="1" />
-                    </ruleList>
-                </createDirectory>
-                <copyFile origin="${installdir}/tmp/packages/${packageName}" destination="${packagesDir}/${packageName}" />
-                <addFilesToUninstaller files="${packagesDir}/${packageName}" />
-            </actionList>
-        </actionDefinition>
-    </functionDefinitionList>
-    <componentList>
-        <component>
-            <name>houdini_19_5</name>
-            <description>Houdini 19.5</description>
-            <selected>0</selected>
-            <postInstallationActionList>
-                <fnCopyHoudiniPackageFile houdiniVersion="19.5" houdiniPackageDir="${houdini_user_pref_dir_default}" />
-            </postInstallationActionList>
-        </component>
-        <component>
-            <name>houdini_20_0</name>
-            <description>Houdini 20.0</description>
-            <selected>0</selected>
-            <postInstallationActionList>
-                <fnCopyHoudiniPackageFile houdiniVersion="20.0" houdiniPackageDir="${houdini_user_pref_dir_default}" />
-            </postInstallationActionList>
-        </component>
-        <component>
-            <name>houdini_20_5</name>
-            <description>Houdini 20.5</description>
-            <selected>0</selected>
-            <postInstallationActionList>
-                <fnCopyHoudiniPackageFile houdiniVersion="20.5" houdiniPackageDir="${houdini_user_pref_dir_default}" />
-            </postInstallationActionList>
-        </component>
-    </componentList>
     <initializationActionList>
         <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_houdini" />
     </initializationActionList>
     <readyToInstallActionList>
         <setInstallerVariable name="houdini_installdir" value="${installdir}/Submitters/Houdini" />
+        <setInstallerVariable name="houdini_packagedir" value="${houdini_installdir}/deadline_package" />
         <if>
             <conditionRuleList>
                 <platformTest type="windows" />
@@ -129,13 +91,17 @@
                 <setInstallerVariable name="houdini_user_pref_dir_default" value="${user_home_directory}/houdini" />
             </actionList>
         </if>
+        <!--To prevent conflicts we delete any copies of our package file in the old install locations-->
+        <deleteFile path="${houdini_user_pref_dir_default}19.5/packages/deadline_submitter_for_houdini.json" />
+        <deleteFile path="${houdini_user_pref_dir_default}20.0/packages/deadline_submitter_for_houdini.json" />
+        <deleteFile path="${houdini_user_pref_dir_default}20.5/packages/deadline_submitter_for_houdini.json" />
     </readyToInstallActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_houdini_summary" ask="0" cliOptionShow="0">
-            <value>Deadline Cloud for Houdini 19.5, 20.0 and 20.5
-- Compatible with Houdini 19.5, 20.0 and 20.5
+            <value>Deadline Cloud for Houdini 19.5-20.5
+- Compatible with Houdini 19.5-20.5
 - Install the integrated Houdini submitter files to the installation directory.
-- Register the plug-in with Houdini by installing and configuring a package file.</value>
+- Register the plug-in package file with Houdini by setting HOUDINI_PACKAGE_DIR</value>
         </stringParameter>
     </parameterList>
     <postInstallationActionList>
@@ -144,6 +110,5 @@
             <zipFile>${installdir}/tmp/houdini_deps/dependency_bundle/deadline_cloud_for_houdini_submitter-deps-${houdini_deps_platform}.zip</zipFile>
         </unzip>
         <deleteFile path="${installdir}/tmp/houdini_deps"/>
-        <deleteFile path="${installdir}/tmp/packages"/>
     </postInstallationActionList>
 </componentGroup>


### PR DESCRIPTION
Fixes: #197 

### What was the problem/requirement? (What/Why)
The installer was not installing deadline cloud for Houdini correctly when doing a system wide install. The package file was only ever being placed in the default Houdini user pref directory.

### What was the solution? (How)
Swapped the installer component to use the env var [`HOUDINI_PACKAGE_DIR`](https://www.sidefx.com/docs/houdini/ref/plugins.html#using_packages) so that both user and system installs work. A nice additional benefit is that we don't have to have multiple subcomponents to select for each version of Houdini anymore.

### What is the impact of this change?
Future installers will work to install Deadline Cloud for Houdini with both user and system installations.

### How was this change tested?
Manually built both Windows and Linux installers and:
* Ran a user install and verified HOUDINI_PACKAGE_DIR was being set and the submitter node loaded and could submit in Houdini 19.5 and 20.5
* Ran a system install and verified HOUDINI_PACKAGE_DIR was being set and the submitter node loaded and could submit in Houdini 19.5 and 20.5

On just Windows I verified that I could install over an existing installation with the current method of putting the package file in the default user pref directory. The previous installation package file was deleted from the default user pref directory. The new installation then set HOUDINI_PACKAGE_DIR. Verified in Houdini's Asset Manager that the correct path to the Node definition was being picked up.

- Have you run the unit tests?
Yes

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
