### PR TITLE
fix(submitter): do not stop finding job attachment files if a node's filename parm could not be evaluated

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
@@ -183,7 +183,7 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
     asset_references.input_filenames.add(_get_hip_file())
 
     # collect references that we could not evaluate so we can surface these later.
-    failed = []
+    failure_messages: dict[str, list[tuple[hou.Parm, str]]] = {}
 
     for parm, ref in hou.fileReferences():
         if (
@@ -205,15 +205,27 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
             if os.path.isfile(path):
                 asset_references.input_filenames.add(parm.unexpandedString())
         except hou.OperationFailed as e:
-            print(e)
-            failed.append((parm, ref))
+            if str(e.instanceMessage()) in failure_messages:
+                failure_messages[str(e.instanceMessage())].append((parm, ref))
+            else:
+                failure_messages[str(e.instanceMessage())] = [(parm, ref)]
             continue
 
-    if failed:
-        print("Failed to evaluate the following references:")
-        for parm, ref in failed:
-            print(f"({parm.name()}, {parm.node()}):{parm} -> {ref}")
-        print("You may need to manually add them to the job attachments.")
+    if failure_messages:
+        failed_references_msg = "Several errors were encountered while collecting file references to include as assets. You may need to manually add them as job attachments."
+        failed_references_details = ""
+        for error_instance in failure_messages:
+            failed_references_details += f"{error_instance}:\n"
+            for parm, ref in failure_messages[error_instance]:
+                failed_references_details += f"\t({parm.name()}, {parm.node()}): {parm} -> {ref}\n"
+
+        hou.ui.displayMessage(
+            failed_references_msg,
+            title="Houdini Asset Parsing",
+            severity=hou.severityType.Warning,
+            details=failed_references_details,
+            details_expanded=True,
+        )
 
     all_inputs = rop_node.inputAncestors()
     for node in all_inputs:

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
@@ -182,6 +182,9 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
     asset_references = AssetReferences()
     asset_references.input_filenames.add(_get_hip_file())
 
+    # collect references that we could not evaluate so we can surface these later.
+    failed = []
+
     for parm, ref in hou.fileReferences():
         if (
             (not parm)
@@ -196,10 +199,21 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
         # the unexpanded version to evaluate afterwards. Allows us to limit
         # files with parameters, such as $F, to one entry instead of possibly
         # hundreds/thousands
-        if os.path.isdir(path):
-            asset_references.input_directories.add(parm.unexpandedString())
-        if os.path.isfile(path):
-            asset_references.input_filenames.add(parm.unexpandedString())
+        try:
+            if os.path.isdir(path):
+                asset_references.input_directories.add(parm.unexpandedString())
+            if os.path.isfile(path):
+                asset_references.input_filenames.add(parm.unexpandedString())
+        except hou.OperationFailed as e:
+            print(e)
+            failed.append((parm, ref))
+            continue
+
+    if failed:
+        print("Failed to evaluate the following references:")
+        for parm, ref in failed:
+            print(f"({parm.name()}, {parm.node()}):{parm} -> {ref}")
+        print("You may need to manually add them to the job attachments.")
 
     all_inputs = rop_node.inputAncestors()
     for node in all_inputs:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When the Houdini submitter fails to parse all asset references in the scene, you get a generic error message. It's not useful to discover what assets were unable to be parsed.

### What was the solution? (How)
Keep track of the assets that failed to parse, and surface these after parsing all the assets. 

### What is the impact of this change?
When an asset returned by `hou.fileReferences()` cannot be collected during parsing, Houdini will display the details of the assets that weren't able to be collected. This will help users debug similar errors. 

![image](https://github.com/user-attachments/assets/806d24c7-1fe3-4c90-bc08-cc6cef0e4f53)

### How was this change tested?
I created a test scene that contained an asset reference that used a KeyFrame in the file name parameter. This causes the collection of this asset to fail since it cannot be found without being evaluated. With the changes I made, the error now includes details about the asset that couldn't be parsed. 


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
