### PR TITLE
chore: fixed dev install to support x86_64 or arm64

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/hatch.toml
+++ b/hatch.toml
@@ -22,7 +22,7 @@ lint = [
 install = "python {root}/scripts/install_dev_submitter.py {args:}"
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [envs.default.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.14"
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",

--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional
 
 
 ADAPTOR_ONLY_DEPENDENCIES = {"openjd-adaptor-runtime"}
+
+
+class CPUArch(Enum):
+    X86_64: str = "x86_64"
+    ARM64: str = "arm64"
 
 
 def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
@@ -62,12 +68,23 @@ def get_git_root() -> Path:
     return Path(__file__).parents[1].resolve()
 
 
-def get_pip_platform(system_platform: str) -> str:
+def get_pip_platform(system_platform: str, cpu_arch: CPUArch = CPUArch.X86_64) -> str:
     if system_platform == "Windows":
-        return "win_amd64"
-    elif system_platform == "Darwin":
-        return "macosx_10_9_x86_64"
-    elif system_platform == "Linux":
-        return "manylinux2014_x86_64"
-    else:
-        raise Exception(f"Unsupported platform: {system_platform}")
+        if cpu_arch is CPUArch.X86_64:
+            return "win_amd64"
+        if cpu_arch is CPUArch.ARM64:
+            return "win_arm64"
+
+    if system_platform == "Darwin":
+        if cpu_arch is CPUArch.X86_64:
+            return "macosx_10_9_x86_64"
+        if cpu_arch is CPUArch.ARM64:
+            return "macosx_11_0_arm64"
+
+    if system_platform == "Linux":
+        if cpu_arch is CPUArch.X86_64:
+            return "manylinux_2_17_x86_64"
+        if cpu_arch is CPUArch.ARM64:
+            return "manylinux_2_17_aarch64"
+
+    raise Exception(f"Unsupported platform/archicture: {system_platform}, {cpu_arch}")

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -7,11 +7,9 @@ import platform
 import re
 import subprocess
 from pathlib import Path
-
 from typing import Optional
 
-from _project import get_git_root, get_dependencies, get_project_dict, get_pip_platform
-
+from _project import CPUArch, get_git_root, get_dependencies, get_project_dict, get_pip_platform
 
 SUBMITTER_PACKAGE_TEMPLATE = {
     "env": [],
@@ -105,7 +103,9 @@ def _resolve_dependencies(local_deps: list[Path]) -> dict[str, str]:
     return json.loads(result.stdout)
 
 
-def _build_deps_env(destination: Path, python_version: str, local_deps: list[Path]) -> None:
+def _build_deps_env(
+    destination: Path, python_version: str, cpu_arch: CPUArch, local_deps: list[Path]
+) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     if not destination.is_dir():
         raise Exception(f"{str(destination)} is not a directory")
@@ -116,22 +116,26 @@ def _build_deps_env(destination: Path, python_version: str, local_deps: list[Pat
         for dep_name, resolved_version in resolved_dependencies_dict.items()
     ]
 
+    pip_platform = get_pip_platform(platform.system(), cpu_arch)
     args = [
         "pip",
         "install",
         "--target",
         str(destination),
         "--platform",
-        get_pip_platform(platform.system()),
+        pip_platform,
         "--python-version",
         python_version,
         "--only-binary=:all:",
         *resolved_dependencies,
     ]
+    print(f"Running: {' '.join(args)}")
     subprocess.run(args, check=True)
 
 
-def install_submitter_package(houdini_version_arg: Optional[str], local_deps: list[Path]) -> None:
+def install_submitter_package(
+    houdini_version_arg: Optional[str], cpu_arch: CPUArch, local_deps: list[Path]
+) -> None:
     houdini_version = HoudiniVersion(houdini_version_arg)
     major_minor = houdini_version.major_minor()
 
@@ -140,6 +144,7 @@ def install_submitter_package(houdini_version_arg: Optional[str], local_deps: li
     _build_deps_env(
         plugin_env_path,
         houdini_version.python_major_minor(),
+        cpu_arch,
         local_deps,
     )
 
@@ -172,6 +177,14 @@ if __name__ == "__main__":
         type=str,
         default=None,
     )
+    cpu_arch_choices = set(e.value for e in CPUArch)
+    parser.add_argument(
+        "--cpu-arch",
+        help="Architecture for python's native deps, should match Houdini's target archicture",
+        type=str,
+        default=platform.machine() if platform.machine() in cpu_arch_choices else None,
+        choices=cpu_arch_choices,
+    )
     parser.add_argument(
         "--local-dep",
         help="Path to a repository containing a dependency for in-place install",
@@ -179,6 +192,7 @@ if __name__ == "__main__":
         type=str,
     )
     args = parser.parse_args()
+    cpu_arch = CPUArch(args.cpu_arch)
     local_deps = [Path(dep) for dep in args.local_dep or []]
 
-    install_submitter_package(args.houdini_version, local_deps)
+    install_submitter_package(args.houdini_version, cpu_arch, local_deps)


### PR DESCRIPTION
Fixes: #218

### What was the problem/requirement? (What/Why)

We were only ever grabbing the x86_64 native dependencies for the dev install. This causes issues for users running any other CPU architecture. In the case of macOS, this specifically caused issues with Apple silicon if Houdini was not running under Rosetta.

### What was the solution? (How)

Added a `--cpu-arch` option that defaults to your current CPU architecture. A user that is emulating Houdini with a different architecture will have to specify this value to match. 

While I was here, I also added python 3.13 to the CIs and as a supported version, even though there isn't a Houdini version that uses python 3.13 yet.

### What is the impact of this change?

Users running Houdini made for Apple silicon can now use `houdini run install` and have it work out of the box.

### How was this change tested?

Ran the hatch run install on macOS specifying the different options and no option.

### Was this change documented?

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
