### PR TITLE
fix: job attachments tab showing unevaluated and evaluated entries for same file

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
@@ -68,10 +68,10 @@ def _get_evaluated_glob_path(parm, globbed_path: str) -> str:
         parm.set(orig_path)
 
 
-def _get_asset_references(rop_node: hou.Node) -> AssetReferences:
+def _get_evaluated_asset_references(rop_node: hou.Node) -> AssetReferences:
     """
     Get the current paths stored in the parms backing the UI and return them as
-    an AssetReferences object
+    an AssetReferences object with any Houdini tokens evaluated
     """
     asset_references = AssetReferences()
 
@@ -103,10 +103,29 @@ def _get_asset_references(rop_node: hou.Node) -> AssetReferences:
     return asset_references
 
 
+def _get_unevaluated_asset_references(rop_node: hou.Node) -> AssetReferences:
+    """
+    Get the current paths stored in the parms backing the UI and return them as
+    an AssetReferences object without evaluating any Houdini tokens
+    """
+    asset_references = AssetReferences()
+    asset_references.input_filenames.update(
+        [n.unexpandedString() for n in rop_node.parm("input_filenames").multiParmInstances()]
+    )
+    asset_references.input_directories.update(
+        [n.unexpandedString() for n in rop_node.parm("input_directories").multiParmInstances()]
+    )
+    asset_references.output_directories.update(
+        [n.unexpandedString() for n in rop_node.parm("output_directories").multiParmInstances()]
+    )
+
+    return asset_references
+
+
 def _get_saved_auto_detected_asset_references(rop_node: hou.Node) -> AssetReferences:
     """
     Get all of the paths saved in the hidden auto_* parms on the node and return
-    them as an AssetReferences object.
+    them as an AssetReferences object in their unevaluated forms.
     """
     saved_auto_refs = AssetReferences()
     saved_auto_refs.input_filenames.update(
@@ -131,7 +150,7 @@ def _parse_files(node: hou.Node):
     based on the detected paths in the scene, any previously saved values and the
     current values in the UI. Then update the UI with the new lists of paths.
     """
-    display_asset_refs = _get_asset_references(node)
+    display_asset_refs = _get_unevaluated_asset_references(node)
     auto_asset_refs = _get_scene_asset_references(node)
     prev_auto_asset_refs = _get_saved_auto_detected_asset_references(node)
 

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -21,7 +21,7 @@ from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentS3Settings
 
 from .queue_parameters import update_queue_parameters, get_queue_parameter_values_as_openjd
-from ._assets import _get_hip_file, _get_asset_references, _parse_files
+from ._assets import _get_hip_file, _get_evaluated_asset_references, _parse_files
 
 # For temporary backwards compatibility
 from ._assets import (
@@ -467,7 +467,7 @@ def parse_files_callback(kwargs):
 def save_bundle_callback(kwargs):
     node = kwargs["node"]
     name = node.parm("name").evalAsString()
-    asset_references = _get_asset_references(node)
+    asset_references = _get_evaluated_asset_references(node)
     try:
         job_bundle_dir = create_job_history_bundle_dir("houdini", name)
         _create_job_bundle(node, job_bundle_dir, asset_references)
@@ -502,7 +502,7 @@ def submit_callback(kwargs):
     name = node.parm("name").evalAsString()
     # TODO: Populate from queue environment so that parameters can be overridden.
     queue_parameters: list[JobParameter] = []
-    asset_references = _get_asset_references(node)
+    asset_references = _get_evaluated_asset_references(node)
 
     # check for locked rops, Karma for example
     locked_rops = []

--- a/test/deadline_submitter_for_houdini/unit/test_assets.py
+++ b/test/deadline_submitter_for_houdini/unit/test_assets.py
@@ -7,7 +7,7 @@ from pytest import param
 
 from .mock_hou import hou_module as hou
 from deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets import (
-    _get_asset_references,
+    _get_evaluated_asset_references,
     _get_scene_asset_references,
     _get_output_directories,
     _houdini_time_vars_to_glob,
@@ -185,8 +185,8 @@ def test_parse_files_manually_added(
             "deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets._get_scene_asset_references"
         ) as mock_get_scene_assets,
         mock.patch(
-            "deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets._get_asset_references"
-        ) as mock_get_asset_references,
+            "deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets._get_unevaluated_asset_references"
+        ) as mock_get_unevaluated_asset_references,
         mock.patch(
             "deadline.houdini_submitter.python.deadline_cloud_for_houdini._assets._update_paths_parm"
         ) as mock_update_paths_parm,
@@ -195,14 +195,14 @@ def test_parse_files_manually_added(
         ) as mock_get_saved_auto_asset_references,
     ):
         mock_get_scene_assets.return_value = auto_detected_assets
-        mock_get_asset_references.return_value = current_assets
+        mock_get_unevaluated_asset_references.return_value = current_assets
         mock_get_saved_auto_asset_references.return_value = prev_auto_detected_assets
 
         node = hou.node
         _parse_files(node)
 
         mock_get_scene_assets.assert_called_once()
-        mock_get_asset_references.assert_called_once()
+        mock_get_unevaluated_asset_references.assert_called_once()
         mock_get_saved_auto_asset_references.assert_called_once()
         mock_update_paths_parm.assert_has_calls(
             [
@@ -417,7 +417,7 @@ def test_filenames_with_frames(tmpdir, pattern: str, filenames: list[str]):
     node.parm.side_effect = input_filenames_override
 
     # WHEN
-    result_refs = _get_asset_references(node)
+    result_refs = _get_evaluated_asset_references(node)
 
     # THEN
     assert result_refs.input_filenames == filesystem
@@ -464,7 +464,7 @@ def test_dirs_with_time_variable(tmpdir):
     node.parm.side_effect = input_filenames_override
 
     # WHEN
-    result_refs = _get_asset_references(node)
+    result_refs = _get_evaluated_asset_references(node)
 
     # THEN
     assert filesystem != matched_filesystem


### PR DESCRIPTION
Fixes: #233 

### What was the problem/requirement? (What/Why)
From the bug description:
```
Clicking Parse Files twice sometimes results in two entries for the same file being added to the job attachments tab. On the first click the unexpanded version with any Houdini tokens in the path is added. On the second click the other fully expanded version is added.
```

This was because we were comparing the evaluated versions of items in the UI to the unevaluated versions stored in the hidden parms.

### What was the solution? (How)
* Added a new function to return all of the asset references from the UI in their unevaluated forms and swapped to using that during checks for manual files and changes
* Renamed the existing function to make it clear that it's returning the evaluated versions of what's displayed in the UI
* Updated all the tests where required

### What is the impact of this change?
Only unevaluated versions of filepaths will display in the job attachments tab and no duplicates in different forms

### How was this change tested?
* Ran all unit tests
* Created a sample scene that caused the issue with the current release and verified that clicking parse files twice added both the unevaluated and evaluated versions of the path
* Ran the same test with my changes and verified that only the unevaluated version was added despite multiple clicks
* Verified that exporting a bundle and submitting a job both still resulted in any Houdini tokens being expanded in the asset_references file saved for the export/submission

- Have you run the unit tests?
Yes

### Was this change documented?

Documented as part of the linked issue

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
