### PR TITLE
fix: bug that caused unhandled exceptions during file parsing

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
@@ -182,9 +182,6 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
     asset_references = AssetReferences()
     asset_references.input_filenames.add(_get_hip_file())
 
-    # collect references that we could not evaluate so we can surface these later.
-    failure_messages: dict[str, list[tuple[hou.Parm, str]]] = {}
-
     for parm, ref in hou.fileReferences():
         if (
             (not parm)
@@ -198,34 +195,13 @@ def _get_scene_asset_references(rop_node: hou.Node) -> AssetReferences:
         # Check the evaluated version to ensure _something_ exists, but add
         # the unexpanded version to evaluate afterwards. Allows us to limit
         # files with parameters, such as $F, to one entry instead of possibly
-        # hundreds/thousands
-        try:
-            if os.path.isdir(path):
-                asset_references.input_directories.add(parm.unexpandedString())
-            if os.path.isfile(path):
-                asset_references.input_filenames.add(parm.unexpandedString())
-        except hou.OperationFailed as e:
-            if str(e.instanceMessage()) in failure_messages:
-                failure_messages[str(e.instanceMessage())].append((parm, ref))
-            else:
-                failure_messages[str(e.instanceMessage())] = [(parm, ref)]
-            continue
-
-    if failure_messages:
-        failed_references_msg = "Several errors were encountered while collecting file references to include as assets. You may need to manually add them as job attachments."
-        failed_references_details = ""
-        for error_instance in failure_messages:
-            failed_references_details += f"{error_instance}:\n"
-            for parm, ref in failure_messages[error_instance]:
-                failed_references_details += f"\t({parm.name()}, {parm.node()}): {parm} -> {ref}\n"
-
-        hou.ui.displayMessage(
-            failed_references_msg,
-            title="Houdini Asset Parsing",
-            severity=hou.severityType.Warning,
-            details=failed_references_details,
-            details_expanded=True,
-        )
+        # hundreds/thousands. hou.fileReferences() already returns the refs as
+        # the equivalent of calling parm.unexpandedString()
+        # https://www.sidefx.com/docs/houdini/hom/hou/fileReferences.html
+        if os.path.isdir(path):
+            asset_references.input_directories.add(ref)
+        if os.path.isfile(path):
+            asset_references.input_filenames.add(ref)
 
     all_inputs = rop_node.inputAncestors()
     for node in all_inputs:

--- a/test/deadline_submitter_for_houdini/unit/test_assets.py
+++ b/test/deadline_submitter_for_houdini/unit/test_assets.py
@@ -32,18 +32,16 @@ def test_get_scene_asset_references():
 
     dir_parm = mock.Mock()
     dir_parm.node.return_value = None
-    dir_parm.unexpandedString.return_value = "/path/assets/"
-    dir_parm.evalAsString.return_value = "/path/assets/"
+    dir_parm.evalAsString.return_value = "/some_expanded_path/assets/"
 
     file_parm = mock.Mock()
     file_parm.node.return_value = None
-    file_parm.unexpandedString.return_value = "/path/asset.png"
-    file_parm.evalAsString.return_value = "/path/asset.png"
+    file_parm.evalAsString.return_value = "/some_expanded_path/image.png"
 
     hou.fileReferences.return_value = (
         # These references should be resolved and added as job attachments
-        (dir_parm, "$HIP/houdini19.5/"),
-        (file_parm, "$HIP/houdini19.5/otls/Deadline-Cloud.hda"),
+        (dir_parm, "$HIP/assets/"),
+        (file_parm, "$HIP/image.png"),
         # These references should all be skipped based on their reference prefix
         (mock_parm, "opdef:$OS.rat"),
         (mock_parm, "oplib:$OS.rat"),
@@ -59,8 +57,8 @@ def test_get_scene_asset_references():
     ):
         asset_refs = _get_scene_asset_references(node)
 
-    assert asset_refs.input_filenames == {"/path/asset.png", "/some/path/test.hip"}
-    assert asset_refs.input_directories == {"/path/assets/"}
+    assert asset_refs.input_filenames == {"$HIP/image.png", "/some/path/test.hip"}
+    assert asset_refs.input_directories == {"$HIP/assets/"}
     assert asset_refs.output_directories == set()
 
 


### PR DESCRIPTION
Copied/based on the previous work and bug report of @paulgolter in #183 due to inactivity on that PR

### What was the problem/requirement? (What/Why)
When parsing the files to include for submission we were calling parm.unexpandedString() on each file path. Filepaths in Houdini can contain a static string path or an expression referencing another parm etc. In certain cases you're unable to call unexpandedString() on the file path parms without causing an exception. Specifically RedShift dome lights have been brought up in the previous PR and other reports. RedShift dome lights contain an inner file path parm with keyframes set on it which results in an error like below when unexpandedString() is called:
```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "C:\PROGRA~1/SIDEEF~1/HOUDIN~1.805/houdini/python3.9libs\hou.py", line 66339, in unexpandedString
    return _hou.Parm_unexpandedString(self)
hou.OperationFailed: The attempted operation failed.
Cannot get unexpanded string for parms with keyframes
```

### What was the solution? (How)
hou.fileReferences() already returns Houdini's interpretation of the parm as an unexpanded string according to their [docs](https://www.sidefx.com/docs/houdini/hom/hou/fileReferences.html). Instead of calling unexpandedString() again we can just use what hou.fileReferences() has already returned.

I've also removed previous debug code that was added to help diagnose which nodes were causing issues with the unexpandedString() calls as we no longer call that function ourselves here.

### What is the impact of this change?
* The use of RedShift dome lights specifically no longer causes unhandled exceptions during file parsing
* Other unknown nodes or use cases should also not run into issues from the additional call to unexpandedString()

### How was this change tested?

* In Houdini 19.5 I created a simple scene with just a RedShift dome light and the Deadline Cloud node
* I added a texture to the RedShift dome light
* Clicked parse files and saw the unhandled exception that the prior PR must have been referring to and visible above
* Modified the submitter code as seen in this PR
* Clicked parse files again and no longer had any unhandled exceptions and the texture on the RedShift dome light was successfully added to the list of input filenames

- Have you run the unit tests?
Yes, and they have been updated to reflect the new behaviour 

### Was this change documented?

Added a description to the commit to hopefully make the changelog more clear of why this was changed

### Is this a breaking change?

Shouldn't be no.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
