### PR TITLE
chore: add default cpu-arch again to pip platform check

### DIFF
--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -69,9 +69,9 @@ def get_git_root() -> Path:
     return Path(__file__).parents[1].resolve()
 
 
-def get_pip_platform(system_platform: str, cpu_arch: CPUArch) -> str:
+def get_pip_platform(system_platform: str, cpu_arch: CPUArch = CPUArch.X86_64) -> str:
     if system_platform == "Windows":
-        if cpu_arch is CPUArch.AMD64:
+        if cpu_arch in [CPUArch.AMD64, CPUArch.X86_64]:
             return "win_amd64"
         if cpu_arch is CPUArch.ARM64:
             return "win_arm64"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
/scripts/deps_bundle.py was failing to run and giving an error like:
```
Traceback (most recent call last):
  File "C:\Users\User\dev\deadline-clients\deadline-cloud-for-houdini\scripts\deps_bundle.py", line 133, in <module>
    build_deps_bundle()
  File "C:\Users\User\dev\deadline-clients\deadline-cloud-for-houdini\scripts\deps_bundle.py", line 124, in build_deps_bundle
    native_dependency_paths = _download_native_dependencies(working_directory, base_env)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\User\dev\deadline-clients\deadline-cloud-for-houdini\scripts\deps_bundle.py", line 58, in _download_native_dependencies
    for plat in map(get_pip_platform, SUPPORTED_PLATFORMS):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: get_pip_platform() missing 1 required positional argument: 'cpu_arch'

```
### What was the solution? (How)
A previous [change](https://github.com/aws-deadline/deadline-cloud-for-houdini/pull/232) had removed the default value for cpu_arch in `get_pip_platform` without realizing it was also used in the dependency bundle script and being relied on there. I've readded the default value the same as it was and added it as a valid value to set the platform to win_amd64.
### What is the impact of this change?
Dev installs still work and so does the deps bundle script.
### How was this change tested?
- With the change I did a dev install to Houdini 19.5 and ensured the submitter was functional still
- With the change I ran the deps_bundle.py script and verified that the same native dependency platforms were present as when run for prior releases of deadline-cloud-for-houdini

#### Please run the integration tests and paste the results below.
N/A

### Was this change documented?
No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
