### PR TITLE
chore: update MacOS install builder archive mapping

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -39,3 +39,4 @@ jobs:
       ref_type: ${{inputs.ref_type}}
       ref: ${{inputs.ref}}
       oses: "['${{inputs.os}}']"
+      project_name: "deadline-cloud-for-houdini"

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -15,7 +15,7 @@ from common import UnsupportedOSError
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
-    "MacOS": "VMware-InstallBuilder-Professional-macos.tar.gz",
+    "Darwin": "VMware-InstallBuilder-Professional-macos.tar.gz",
 }
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- platform.system() returns `Darwin` not `MacOS` so the check for the install builder archive was failing
- The workflow to build installers requires a project_name as input
### What was the solution? (How)
- Changed mapping to `Darwin`
- Added `deadline-cloud-for-houdini` as the project_name
### What is the impact of this change?
- Dev builds of the installer worked on all 3 OSes
### How was this change tested?
In my own dev setup by running the workflows and seeing the installers build for all 3 OSes

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
