### PR TITLE
fix: escaped characters in paths on Windows install

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -35,7 +35,7 @@
                     <type>exact</type>
                     <encoding>utf-8</encoding>
                     <substitutionList>
-                        <substitution pattern="INSTALL_DIR_PLACEHOLDER" value="${houdini_installdir}" />
+                        <substitution pattern="INSTALL_DIR_PLACEHOLDER" value="${houdini_installdir.unix}" />
                     </substitutionList>
                 </substitute>
                 <fnAddPathEnvironmentVariable>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A recent change re-added a previously fixed bug #123 

### What was the solution? (How)
Swap to unix style paths again like previously done: https://github.com/aws-deadline/deadline-cloud-for-houdini/pull/192

### What is the impact of this change?
Not reintroducing previously fixed bugs

### How was this change tested?

Built an installer locally and ensured I could install again to a folder path containing a `\b` on Windows

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
