### PR TITLE
fix: ROP Geometry nodes not being evaluated

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/_assets.py
@@ -344,6 +344,7 @@ _NODE_DIR_MAP = {
     "Driver/ris::3.0": _renderman_outputs,  # Renderman
     "Driver/Redshift_ROP": "RS_outputFileNamePrefix",  # Redshift
     "Sop/rop_alembic": "filename",  # ROP Alembic Output
+    "Sop/rop_geometry": "sopoutput",  # ROP Geometry Output
     "Dop/rop_dop": "dopoutput",  # ROP Output Driver
     "Driver/usdrender": _usd_render_outputs,  # USD Render ROP
     "Lop/usdrender_rop": _usd_render_outputs,  # USD Render LOP ROP

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -223,7 +223,7 @@ def _get_render_strategy_for_node(node: hou.Node) -> RenderStrategy:
     render_strategy = RenderStrategy.PARALLEL
 
     if (
-        node.type().nameWithCategory() == "Driver/geometry"
+        node.type().nameWithCategory() in ["Driver/geometry", "Sop/rop_geometry"]
         and node.parm("initsim")
         and node.parm("initsim").eval()
     ):


### PR DESCRIPTION
Fixes: #255 

### What was the problem/requirement? (What/Why)
ROP geometry nodes were not being evaluated to detect output paths or if they should be run as a single task for simulations

### What was the solution? (How)
The ROP Geometry node has a different driver type than the regular Geometry nodes so I've added the driver to the list of nodes to check for `initsim` and the mapping for where to look for output files.

### What is the impact of this change?
* Output files are found
* initsim being selected results in only a single task being created

### How was this change tested?

* Created a scene locally with a ROP Geometry node
* Selected the Initialize Simulation option in the node
* Parsed files and saw that the output directory was not added to the list
* Submitted the job and saw that one task was created for every frame despite initsim being set

Made my changes
* Parsed files and saw that the output directory was added to the list correctly
* Submitted the job and saw that only a single task was created for all frames so initsim was being respects

Also tried using a fetch node like the original bug described and everything still worked correctly.

- Have you run the unit tests?
Yes

#### Please run the integration tests and paste the results below.

### Was this change documented?

Documented in the GitHub issue

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
