### PR TITLE
fix: Add manual path mapping for environment variables

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -36,6 +36,38 @@ class HoudiniHandler:
         self.wedge = None
         self.wegenum = None
 
+    def _perform_path_mapping(self) -> None:
+        """
+        Applies the contents of HOUDINI_PATHMAP to global variables
+        in case they are not automatically re-mapped.
+        """
+
+        # Use the HScript command `setenv` to retrieve all global variables as a tuple:
+        # [0] all environment variables in one string, each with the format "KEY\t= VAL\n"
+        # [1] any errors from running the command
+        # https://www.sidefx.com/docs/houdini/commands/setenv.html
+        set_envs, err = hou.hscript("setenv")
+
+        # Early return on errors in case they are benign
+        if err:
+            print(f"Error retrieving Houdini environment variables: {err}")
+            return
+
+        for line in set_envs.split("\n"):
+            if line.strip():
+                key, val = line.split("\t= ", 1)
+                # Use the `pathmap` command to apply HOUDINI_PATHMAP to each variable
+                # in case it missed mapping.
+                # `-t` (test) applies the path mapping rules to the given path
+                # `-c` (compact) prints out just the re-mapped path (with a newline we must strip)
+                mapped_path, err = hou.hscript(f"pathmap -t '{val}' -c")
+                if not err and mapped_path:
+                    hou.putenv(key, mapped_path.strip())
+                    print(f"Set {key} to {mapped_path.strip()}")
+
+        # Reload the env variables
+        hou.hscript("varchange")
+
     def set_node_settings(self, node):
         # this is a place holder function
         # TODO remove after common node library implemented
@@ -204,3 +236,6 @@ class HoudiniHandler:
             hou.hipFile.load(scene_path)
         except hou.LoadWarning as e:
             print(e)
+            return
+
+        self._perform_path_mapping()

--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -36,34 +36,28 @@ class HoudiniHandler:
         self.wedge = None
         self.wegenum = None
 
-    def _perform_path_mapping(self) -> None:
+    def _path_map_envs(self) -> None:
         """
         Applies the contents of HOUDINI_PATHMAP to global variables
-        in case they are not automatically re-mapped.
+        that are not automatically re-mapped.
         """
 
-        # Use the HScript command `setenv` to retrieve all global variables as a tuple:
-        # [0] all environment variables in one string, each with the format "KEY\t= VAL\n"
-        # [1] any errors from running the command
-        # https://www.sidefx.com/docs/houdini/commands/setenv.html
-        set_envs, err = hou.hscript("setenv")
+        # We know that $JOB and $POSE are not pathmapped automatically,
+        # because they don't change when a scene file moves:
+        # https://www.sidefx.com/docs/houdini/basics/project.html#tips-and-notes
+        envs_to_remap: list[str] = ["JOB", "POSE"]
 
-        # Early return on errors in case they are benign
-        if err:
-            print(f"Error retrieving Houdini environment variables: {err}")
-            return
-
-        for line in set_envs.split("\n"):
-            if line.strip():
-                key, val = line.split("\t= ", 1)
-                # Use the `pathmap` command to apply HOUDINI_PATHMAP to each variable
-                # in case it missed mapping.
-                # `-t` (test) applies the path mapping rules to the given path
-                # `-c` (compact) prints out just the re-mapped path (with a newline we must strip)
-                mapped_path, err = hou.hscript(f"pathmap -t '{val}' -c")
-                if not err and mapped_path:
-                    hou.putenv(key, mapped_path.strip())
-                    print(f"Set {key} to {mapped_path.strip()}")
+        for env in envs_to_remap:
+            print(f"Mapping {env} ({hou.getenv(env)})")
+            # Use the `pathmap` command to apply HOUDINI_PATHMAP to each variable
+            # in case it missed mapping.
+            # `-t` (test) applies the path mapping rules to the given path
+            # `-c` (compact) prints out just the re-mapped path (with a newline we must strip)
+            # https://www.sidefx.com/docs/houdini/commands/pathmap.html
+            mapped_path, err = hou.hscript(f"pathmap -t '{hou.getenv(env)}' -c")
+            if not err and mapped_path:
+                hou.putenv(env, mapped_path.strip())
+                print(f"Set {env} to {mapped_path.strip()}")
 
         # Reload the env variables
         hou.hscript("varchange")
@@ -236,6 +230,5 @@ class HoudiniHandler:
             hou.hipFile.load(scene_path)
         except hou.LoadWarning as e:
             print(e)
-            return
 
-        self._perform_path_mapping()
+        self._path_map_envs()

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
@@ -82,11 +82,14 @@ class TestHoudiniHandler:
             # test file not found
             handler.set_scene_file(data)
 
+    @patch(
+        "deadline.houdini_adaptor.HoudiniClient.houdini_handler.HoudiniHandler._perform_path_mapping"
+    )
     def test_set_scene_file_loads(self, capfd) -> None:
         handler = HoudiniHandler()
         data = {"scene_file": "/not/a/real/scene.hip"}
         with patch(
-            "deadline.houdini_adaptor.HoudiniClient.houdini_handler.os.path.isfile"
+            "deadline.houdini_adaptor.HoudiniClient.houdini_handler.os.path.isfile",
         ) as mock_isfile:
             mock_isfile.return_value = True
             # test file loads

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
@@ -82,10 +82,8 @@ class TestHoudiniHandler:
             # test file not found
             handler.set_scene_file(data)
 
-    @patch(
-        "deadline.houdini_adaptor.HoudiniClient.houdini_handler.HoudiniHandler._perform_path_mapping"
-    )
-    def test_set_scene_file_loads(self, capfd) -> None:
+    @patch("deadline.houdini_adaptor.HoudiniClient.houdini_handler.HoudiniHandler._path_map_envs")
+    def test_set_scene_file_loads(self, patch_pathmap, capfd) -> None:
         handler = HoudiniHandler()
         data = {"scene_file": "/not/a/real/scene.hip"}
         with patch(
@@ -96,7 +94,8 @@ class TestHoudiniHandler:
             handler.set_scene_file(data)
             hou.hipFile.load.assert_called_once()
 
-    def test_set_scene_file_raise_exception(self, capfd) -> None:
+    @patch("deadline.houdini_adaptor.HoudiniClient.houdini_handler.HoudiniHandler._path_map_envs")
+    def test_set_scene_file_raise_exception(self, patch_pathmap, capfd) -> None:
         handler = HoudiniHandler()
         data = {"scene_file": "/not/a/real/scene.hip"}
         with patch(


### PR DESCRIPTION
Fixes: #245 

### What was the problem/requirement? (What/Why)
Redshift render nodes using the `$JOB` token will not be pathmapped properly, causing renders to fail. Please see the linked issue for more context.

### What was the solution? (How)
Re-pathmap environment variables after opening a scene s.t. the `$JOB` token will be properly re-evaluated before rendering to a location that doesn't exist.

### What is the impact of this change?
This behaviour is only seen with Redshift, possibly because of an error with its pathmapping (i.e., any output path using `HOUDINI_PATHMAP` has been fine so far). This is a workaround that allows Redshift nodes to save files to a pathmapped location.

### How was this change tested?
Ran unit tests.

Rendered a test scene with a `RS_Render` node and its output location set to `$JOB/render/file.exr`; saw that the render succeeded and looks as expected.

#### Please run the integration tests and paste the results below.
Houdini 20.0:
```
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter

================================================= slowest 5 durations =================================================
16.79s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.02s setup    test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s teardown test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
================================================= 1 passed in 18.75s ==================================================
```
Houdini 20.5:
```
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter

================================================= slowest 5 durations =================================================
15.07s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.01s setup    test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s teardown test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
================================================= 1 passed in 16.05s ==================================================
```

Couldn't run on 19.5; seems the new installer scripts broke our `hatch run install` script for Houdini 20.5. Cut an issue #258

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
N/A

### Was this change documented?
nop
### Is this a breaking change?
nop
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
