### PR TITLE
feat: add Redshift pathmapping support

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniAdaptor/adaptor.py
+++ b/src/deadline/houdini_adaptor/HoudiniAdaptor/adaptor.py
@@ -8,6 +8,7 @@ import re
 import sys
 import threading
 import time
+from pathlib import Path
 from functools import wraps
 from typing import Callable
 
@@ -19,6 +20,7 @@ from openjd.adaptor_runtime.process import LoggingSubprocess
 from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
 from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
 from openjd.adaptor_runtime_client import Action
+from openjd.adaptor_runtime._utils import secure_open
 
 from .._version import version as adaptor_version
 
@@ -337,12 +339,9 @@ class HoudiniAdaptor(Adaptor[AdaptorConfiguration]):
         else:
             os.environ["PYTHONPATH"] = python_path_addition
 
-        # If there are path mapping rules, set the houdini environment variable to enable them
-        houdini_pathmap = self._get_houdini_pathmap()
-        if houdini_pathmap:
-            os.environ["HOUDINI_PATHMAP"] = houdini_pathmap
-
-        _logger.info("Setting HOUDINI_PATHMAP to: {}".format(houdini_pathmap))
+        # Set any path mapping rules
+        self._set_houdini_pathmap()
+        self._set_redshift_pathmap()
 
         houdini_client_path = self._get_houdini_client_path()
 
@@ -352,24 +351,104 @@ class HoudiniAdaptor(Adaptor[AdaptorConfiguration]):
             stderr_handler=regexhandler,
         )
 
-    def _get_houdini_pathmap(self) -> str:
+    def _set_houdini_pathmap(self) -> None:
         """Builds a dict of source to destination strings from the path mapping rules
-
-        The string representation of the dict can then be used to set HOUDINI_PATHMAP
-
-        Returns:
-            str: The value to set HOUDINI_PATHMAP to
+        and sets HOUDINI_PATHMAP to the string representation of the dict.
         """
-        path_mapping_rules: dict[str, str] = {}
+        if not self.path_mapping_rules:
+            return
 
-        for rule in self._path_mapping_rules:
-            path_mapping_rules[rule.source_path.replace("\\", "/")] = rule.destination_path.replace(
-                "\\", "/"
+        houdini_mapping_rules: dict[str, str] = {}
+
+        for rule in self.path_mapping_rules:
+            houdini_mapping_rules[rule.source_path.replace("\\", "/")] = (
+                rule.destination_path.replace("\\", "/")
             )
 
-        if path_mapping_rules:
-            return str(path_mapping_rules)
-        return ""
+        _logger.info(f"Setting HOUDINI_PATHMAP to: {str(houdini_mapping_rules)}")
+        os.environ["HOUDINI_PATHMAP"] = str(houdini_mapping_rules)
+
+    def _set_redshift_pathmap(self) -> None:
+        """Builds a dict of source to destination strings from the path mapping rules
+        and writes them to a temporary file to point Redshift to for path mapping.
+
+        This is sometimes needed when using Redshift proxy files which contain both relative
+        and absolute paths to any external file references. If the proxy file is moved and
+        the relative paths are no longer correct, then the absolute paths will need to
+        be mapped using REDSHIFT_PATHOVERRIDE_FILE.
+
+        https://help.maxon.net/r3d/houdini/en-us/Content/html/Intro+to+Proxies.html
+        """
+
+        if not self.path_mapping_rules:
+            return
+
+        # Redshift expects double quoted space delimited "source" "destination" pairs
+        # example: "C:/Users/AUser/Directory" "/sessions/session-abcd/"
+        # https://help.maxon.net/r3d/houdini/en-us/Content/html/Redshift+Environment+Variables.html
+        redshift_rules = " ".join(
+            [
+                '"{source}" "{dest}"'.format(
+                    source=rule.source_path.replace("\\", "/"),
+                    dest=rule.destination_path.replace("\\", "/"),
+                )
+                for rule in self.path_mapping_rules
+            ]
+        )
+
+        # Collect any additional rules if REDSHIFT_PATHOVERRIDE_FILE is already set
+        if existing_rule_file_path := os.getenv("REDSHIFT_PATHOVERRIDE_FILE"):
+            _logger.info(
+                f"Found existing REDSHIFT_PATHOVERRIDE_FILE environment variable: {existing_rule_file_path}"
+            )
+            try:
+                with secure_open(
+                    existing_rule_file_path, open_mode="r", encoding="utf-8"
+                ) as existing_rule_file:
+                    redshift_rules += " " + " ".join(existing_rule_file.read().splitlines())
+            except FileNotFoundError as e:
+                _logger.warning(
+                    f"The file pointed to by the REDSHIFT_PATHOVERRIDE_FILE environment variable does not exist at {existing_rule_file_path} : {str(e)}"
+                )
+            except PermissionError as e:
+                _logger.warning(
+                    f"Missing permissions to read the REDSHIFT_PATHOVERRIDE_FILE at {existing_rule_file_path}: {str(e)}"
+                )
+            except Exception as e:
+                _logger.warning(
+                    f"Error reading the REDSHIFT_PATHOVERRIDE_FILE at {existing_rule_file_path}: {str(e)}"
+                )
+
+        # Collect any additional rules if REDSHIFT_PATHOVERRIDE_STRING is already set
+        # and REDSHIFT_PATHOVERRIDE_FILE was not already set, Redshift by default
+        # will take only the file if both it and the string are set.
+        if not existing_rule_file_path and (
+            existing_rule_str := os.getenv("REDSHIFT_PATHOVERRIDE_STRING")
+        ):
+            _logger.info(f"Found existing REDSHIFT_PATHOVERRIDE_STRING: {existing_rule_str}")
+            redshift_rules += " " + existing_rule_str
+
+        # Write all rules to a new temp override file and point to it
+        # It was tested and verified that all of the rules can be on a single line
+        # in the file.
+        new_pathmap_file_path = Path(os.getcwd(), "redshift_pathmap_override.txt")
+        try:
+            with secure_open(
+                new_pathmap_file_path, open_mode="w", encoding="utf-8"
+            ) as new_pathmap_file:
+                new_pathmap_file.writelines(redshift_rules)
+                _logger.info(
+                    f"Setting REDSHIFT_PATHOVERRIDE_FILE path to: {str(new_pathmap_file_path)} with the rules {redshift_rules}"
+                )
+                os.environ["REDSHIFT_PATHOVERRIDE_FILE"] = str(new_pathmap_file_path)
+        except PermissionError as e:
+            _logger.warning(
+                f"Redshift path mapping rules not set due to missing permissions to write the REDSHIFT_PATHOVERRIDE_FILE at {new_pathmap_file_path}: {str(e)}"
+            )
+        except Exception as e:
+            _logger.warning(
+                f"Redshift path mapping rules not set due to an error writing the REDSHIFT_PATHOVERRIDE_FILE at {new_pathmap_file_path}: {str(e)}"
+            )
 
     def on_start(self) -> None:
         """

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/conftest.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/conftest.py
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from unittest.mock import patch, Mock, PropertyMock
+from typing import Generator
+from deadline.houdini_adaptor.HoudiniAdaptor import HoudiniAdaptor
+
+
+@pytest.fixture()
+def init_data() -> dict:
+    """
+    Pytest Fixture to return an init_data dictionary that passes validation
+
+    Returns:
+        dict: An init_data dictionary
+    """
+    return {
+        "scene_file": "/path/to/scene/houdiniscene-19.5.hip",
+        "version": "19.5.435",
+        "render_node": "mantra1",
+        "wedge_node": "",
+        "wedgenum": "",
+        "ignore_input_nodes": True,
+    }
+
+
+@pytest.fixture()
+def run_data() -> dict:
+    """
+    Pytest Fixture to return a run_data dictionary that passes validation
+
+    Returns:
+        dict: A run_data dictionary
+    """
+    return {"frame_range": {"start": 1, "end": 5, "step": 2}}
+
+
+@pytest.fixture(autouse=True)
+def mock_config() -> Generator[Mock, None, None]:
+    config_mock = Mock()
+    config_mock.get_executable_path.return_value = "/path/to/houdini/hython"
+
+    with patch.object(HoudiniAdaptor, "config", new_callable=PropertyMock) as mock:
+        mock.return_value = config_mock
+        yield config_mock

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from itertools import chain
 import os
-from typing import Generator
 from unittest.mock import Mock, PropertyMock, call, patch
 
 import pytest
@@ -15,45 +14,6 @@ from deadline.houdini_adaptor.HoudiniAdaptor.adaptor import (
     _REQUIRED_HOUDINI_INIT_KEYS,
     HoudiniNotRunningError,
 )
-
-
-@pytest.fixture()
-def init_data() -> dict:
-    """
-    Pytest Fixture to return an init_data dictionary that passes validation
-
-    Returns:
-        dict: An init_data dictionary
-    """
-    return {
-        "scene_file": "/path/to/scene/houdiniscene-19.5.hip",
-        "version": "19.5.435",
-        "render_node": "mantra1",
-        "wedge_node": "",
-        "wedgenum": "",
-        "ignore_input_nodes": True,
-    }
-
-
-@pytest.fixture()
-def run_data() -> dict:
-    """
-    Pytest Fixture to return a run_data dictionary that passes validation
-
-    Returns:
-        dict: A run_data dictionary
-    """
-    return {"frame_range": {"start": 1, "end": 5, "step": 2}}
-
-
-@pytest.fixture(autouse=True)
-def mock_config() -> Generator[Mock, None, None]:
-    config_mock = Mock()
-    config_mock.get_executable_path.return_value = "/path/to/houdini/hython"
-
-    with patch.object(HoudiniAdaptor, "config", new_callable=PropertyMock) as mock:
-        mock.return_value = config_mock
-        yield config_mock
 
 
 class TestHoudiniAdaptor_on_start:

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor_pathmapping.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor_pathmapping.py
@@ -1,0 +1,239 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+from pathlib import Path
+import pytest
+from openjd.adaptor_runtime.adaptors import PathMappingRule
+from deadline.houdini_adaptor.HoudiniAdaptor import HoudiniAdaptor
+from typing import Optional
+
+
+houdini_pathmap_test_cases = [
+    pytest.param([], None, id="No pathmapping rules"),
+    pytest.param(
+        [
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/home/users/usera/folder",
+                destination_path="/sessions/session-abc",
+            )
+        ],
+        "{'/home/users/usera/folder': '/sessions/session-abc'}",
+        id="Single pathmapping rule",
+    ),
+    pytest.param(
+        [
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/sourcea/testa",
+                destination_path="/sessions/session-abc",
+            ),
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/sourceb/testb",
+                destination_path="/sessions/session-abc",
+            ),
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/sourcec/testc",
+                destination_path="/sessions/session-abc",
+            ),
+        ],
+        "{'/sourcea/testa': '/sessions/session-abc', '/sourceb/testb': '/sessions/session-abc', '/sourcec/testc': '/sessions/session-abc'}",
+        id="Mutliple pathmapping rules",
+    ),
+    pytest.param(
+        [
+            PathMappingRule(
+                source_path_format="Windows",
+                source_path="C:\\Users\\usera\\folder",
+                destination_path="/sessions/session-abc",
+            ),
+        ],
+        "{'C:/Users/usera/folder': '/sessions/session-abc'}",
+        id="Backslashes in rule",
+    ),
+]
+
+
+@pytest.mark.parametrize(("input_rules", "houdini_pathmap"), houdini_pathmap_test_cases)
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_set_houdini_pathmap(
+    init_data,
+    input_rules: list[PathMappingRule],
+    houdini_pathmap: str,
+) -> None:
+
+    # GIVEN
+    adaptor = HoudiniAdaptor(init_data)
+    adaptor._path_mapping_rules = input_rules
+
+    assert "HOUDINI_PATHMAP" not in os.environ
+
+    # WHEN
+    adaptor._set_houdini_pathmap()
+
+    # THEN
+    assert os.environ.get("HOUDINI_PATHMAP") == houdini_pathmap
+
+
+redshift_pathmap_test_cases = [
+    pytest.param({}, [], "", id="No rules, no pre-existing file or string override"),
+    pytest.param(
+        {},
+        [
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/home/users/usera/folder",
+                destination_path="/sessions/session-abc",
+            )
+        ],
+        '"/home/users/usera/folder" "/sessions/session-abc"',
+        id="Single rule, no pre-existing file or string override",
+    ),
+    pytest.param(
+        {},
+        [
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/sourcea/testa",
+                destination_path="/sessions/session-abc",
+            ),
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/sourceb/testb",
+                destination_path="/sessions/session-abc",
+            ),
+            PathMappingRule(
+                source_path_format="Linux",
+                source_path="/sourcec/testc",
+                destination_path="/sessions/session-abc",
+            ),
+        ],
+        '"/sourcea/testa" "/sessions/session-abc" "/sourceb/testb" "/sessions/session-abc" "/sourcec/testc" "/sessions/session-abc"',
+        id="Multiple rules, no pre-existing file or string override",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("input_env", "input_rules", "expected_output_rules"),
+    redshift_pathmap_test_cases,
+)
+def test_set_redshift_pathmap(
+    init_data,
+    input_env: dict[str, str],
+    input_rules: list[PathMappingRule],
+    expected_output_rules: set[str],
+    tmp_path: Path,
+) -> None:
+
+    # GIVEN
+    with (mock.patch.dict(os.environ, input_env, clear=True),):
+        adaptor = HoudiniAdaptor(init_data)
+        adaptor._path_mapping_rules = input_rules
+        tmp_rs_rule_filepath = Path(tmp_path, "temp_rs_rules.txt")
+        with mock.patch(
+            "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.Path",
+            return_value=tmp_rs_rule_filepath,
+        ):
+            # WHEN
+            adaptor._set_redshift_pathmap()
+
+            # THEN
+            if expected_output_rules:
+                assert os.environ["REDSHIFT_PATHOVERRIDE_FILE"] == str(tmp_rs_rule_filepath)
+                with open(tmp_rs_rule_filepath, mode="r", encoding="utf-8") as rs_rule_file:
+                    rs_rules = rs_rule_file.readlines()
+                assert len(rs_rules) == 1
+                assert rs_rules[0] == expected_output_rules
+            else:
+                assert os.environ.get("REDSHIFT_PATHOVERRIDE_FILE") is None
+
+
+@pytest.mark.parametrize(
+    ("existing_file_content", "existing_string_content", "input_rules", "expected_output_rules"),
+    [
+        pytest.param(
+            '"/existing/path1" "/existing/dest1"\n"/existing/path2" "/existing/dest2"',
+            None,
+            [
+                PathMappingRule(
+                    source_path_format="Linux",
+                    source_path="/new/path",
+                    destination_path="/sessions/session-abc",
+                )
+            ],
+            '"/new/path" "/sessions/session-abc" "/existing/path1" "/existing/dest1" "/existing/path2" "/existing/dest2"',
+            id="Existing override file with rules",
+        ),
+        pytest.param(
+            None,
+            '"/existing/path1" "/existing/dest1" "/existing/path2" "/existing/dest2"',
+            [
+                PathMappingRule(
+                    source_path_format="Linux",
+                    source_path="/new/path",
+                    destination_path="/sessions/session-abc",
+                )
+            ],
+            '"/new/path" "/sessions/session-abc" "/existing/path1" "/existing/dest1" "/existing/path2" "/existing/dest2"',
+            id="Existing override string with rules",
+        ),
+        pytest.param(
+            '"/existing/path1" "/existing/dest1" "/existing/path2" "/existing/dest2"\n"/one/moresource" "/one/moredest"',
+            '"/existing/path3" "/existing/dest3" "/existing/path4" "/existing/dest4"',
+            [
+                PathMappingRule(
+                    source_path_format="Linux",
+                    source_path="/new/path",
+                    destination_path="/sessions/session-abc",
+                )
+            ],
+            '"/new/path" "/sessions/session-abc" "/existing/path1" "/existing/dest1" "/existing/path2" "/existing/dest2" "/one/moresource" "/one/moredest"',
+            id="Existing override string and file with rules",
+        ),
+    ],
+)
+def test_set_redshift_pathmap_with_existing_file_and_string(
+    init_data,
+    existing_file_content: Optional[str],
+    existing_string_content: Optional[str],
+    input_rules: list[PathMappingRule],
+    expected_output_rules: str,
+    tmp_path: Path,
+) -> None:
+
+    # GIVEN
+    input_env = {}
+
+    if existing_file_content:
+        existing_file = Path(tmp_path, "existing_rules.txt")
+        with open(existing_file, "w", encoding="utf-8") as f:
+            f.write(existing_file_content)
+        input_env["REDSHIFT_PATHOVERRIDE_FILE"] = str(existing_file)
+
+    if existing_string_content:
+        input_env["REDSHIFT_PATHOVERRIDE_STRING"] = existing_string_content
+
+    with (mock.patch.dict(os.environ, input_env, clear=True),):
+        adaptor = HoudiniAdaptor(init_data)
+        adaptor._path_mapping_rules = input_rules
+        tmp_rs_rule_file = Path(tmp_path, "tmp_rs_rules.txt")
+
+        with mock.patch(
+            "deadline.houdini_adaptor.HoudiniAdaptor.adaptor.Path",
+            return_value=tmp_rs_rule_file,
+        ):
+            # WHEN
+            adaptor._set_redshift_pathmap()
+
+            # THEN
+            assert os.environ["REDSHIFT_PATHOVERRIDE_FILE"] == str(tmp_rs_rule_file)
+            with open(tmp_rs_rule_file, mode="r", encoding="utf-8") as rs_rule_file:
+                rs_rules = rs_rule_file.readlines()
+            assert len(rs_rules) == 1
+            assert rs_rules[0] == expected_output_rules


### PR DESCRIPTION
Fixes: #228  

### What was the problem/requirement? (What/Why)
HOUDINI_PATHMAP appears to work on Redshift nodes directly in the Houdini scene, but for any references inside Redshift proxy files where the relative paths are no longer correct there is no built-in support to re-pathmap them. Note: Redshift proxies do contain both the relative and absolute paths of any external file references, but there can be situations where the relative paths are no longer correct and the absolute paths need to be remapped.

### What was the solution? (How)
In addition to HOUDINI_PATHMAP the adaptor will now also collect any pathmapping rules from the service or set by REDSHIFT_PATHOVERRIDE_STRING and REDSHIFT_PATHOVERRIDE_FILE and combine them into a new temporary file that REDSHIFT_PATHOVERRIDE_FILE is then set to for Redshift to pathmap any references it needs to. Verified that the override file can have all of the rules on the same line.

### What is the impact of this change?
The Redshift specific pathmapping variable is set.

### How was this change tested?
* Ran all existing unit tests and added new ones related to pathmapping including many scenarios with the new Redshift logic
* Did a submission with our current adaptor available in SMF with a scene that references a Redshift proxy file and verified that I got missing texture errors and the texture was missing from the output
* Did a submission with a dev build of the adapator with the Redshift pathmapping changes and the same scene as above. Verified that I saw the logging messages of REDSHIFT_PATHOVERRIDE_FILE being set and that during rendering there were no errors for missing textures. The output showed the texture from the proxy file as well.
* Ran a real test with a queue env setting REDSHIFT_PATHOVERRIDE_STRING and FILE to confirm that all rules are being picked up and set in the new file.

- Have you run the unit tests?
Yes

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
