### PR TITLE
fix: properly clean up env vars created by the installer

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -201,7 +201,7 @@
                 <setInstallerVariable name="houdini_installdir" value="${installdir}/Submitters/Houdini"/>
             </elseActionList>
         </if>
-        <setInstallerVariable name="houdini_packagedir" value="${houdini_installdir}/deadline_package" />
+        <setInstallerVariable name="houdini_packagedir" value="${houdini_installdir}/deadline_package" persist="1" />
     </readyToInstallActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_houdini_summary" ask="0" cliOptionShow="0">
@@ -219,4 +219,12 @@
         </unzip>
         <deleteFile path="${installdir}/tmp"/>
     </postInstallationActionList>
+    <postUninstallationActionList>
+        <fnRemovePathFromEnvironmentVariable name="HOUDINI_PACKAGE_DIR" value="${houdini_packagedir}" scope="${installscope}">
+            <progressText>Unsetting HOUDINI_PACKAGE_DIR</progressText>
+            <ruleList>
+                <platformTest type="windows"/>
+            </ruleList>
+        </fnRemovePathFromEnvironmentVariable>
+    </postUninstallationActionList>
 </componentGroup>

--- a/installer/DeadlineCloudForHoudiniSubmitter.xml
+++ b/installer/DeadlineCloudForHoudiniSubmitter.xml
@@ -81,6 +81,35 @@
                 <addEnvironmentVariable name="${name}" value="${new_value}" scope="${scope}"/>
             </actionList>
         </actionDefinition>
+        <actionDefinition name="fnRemovePathFromEnvironmentVariable">
+            <parameterList>
+                <stringParameter name="name"/>
+                <stringParameter name="value"/>
+                <stringParameter name="scope" default="user"/>
+            </parameterList>
+            <actionList>
+                <logMessage text="Comparing '${env(${name})}' and ${value}"/>
+                <if>
+                    <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                    <conditionRuleList>
+                        <!-- <regExMatch text="${env(${name}).escape_backslashes}" logic="matches" pattern="(?:[;:]|^)${value.escape_backslashes}(?:[;:]|$)"/> -->
+                        <compareText text="${env(${name})}" logic="equals" value="${value}"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <deleteEnvironmentVariable name="${name}" scope="${scope}"/>
+                    </actionList>
+                    <elseActionList>
+                        <setInstallerVariableFromRegEx>
+                            <name>new_value</name>
+                            <pattern>(?:[;:]|^)${value.escape_backslashes}(?:[;:]|$)</pattern>
+                            <substitution>${platform_env_path_sep}</substitution>
+                            <text>${env(${name})}</text>
+                        </setInstallerVariableFromRegEx>
+                        <addEnvironmentVariable name="${name}" value="${new_value}" scope="${scope}"/>
+                    </elseActionList>
+                </if>
+            </actionList>
+        </actionDefinition>
     </functionDefinitionList>
 
     <componentList>
@@ -189,6 +218,17 @@
             </ruleList>
         </actionGroup>
         <deleteFile path="${installdir}/installer_version.txt"/>
+        <if>
+            <conditionRuleList>
+                <platformTest type="windows"/>
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="platform_env_path_sep" value=";"/>
+            </actionList>
+            <elseActionList>
+                <setInstallerVariable name="platform_env_path_sep" value=":"/>
+            </elseActionList>
+        </if>
     </preUninstallationActionList>
     <width>550</width>
 </project>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The installer on Windows would leave behind environment variables after running the uninstaller.

### What was the solution? (How)
Add in steps to remove these env vars during uninstallation.

### What is the impact of this change?
We properly clean up installed artifacts.

### How was this change tested?

Built the installer locally and ran it on a Windows instance. Confirmed that the path to our installation folder gets cleaned up appropriately both when there is already a value present and when it is the only one.

- Have you run the unit tests?
No. This code does no effect the unit tests.

#### #### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
```bash
=================================================== test session starts ====================================================
platform darwin -- Python 3.12.7, pytest-8.3.5, pluggy-1.6.0 -- /Users/justins/Library/Application Support/hatch/env/virtual/deadline-cloud-for-houdini/9wTjeyA9/deadline-cloud-for-houdini/bin/python
cachedir: .pytest_cache
rootdir: /Users/justins/dev/github/aws-deadline/deadline-cloud-for-houdini
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
10 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw4] [  7%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw9] [ 15%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw5] [ 23%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw1] [ 30%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 38%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw3] [ 46%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw8] [ 53%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

===================================================== warnings summary =====================================================
test/installer/test_installer.py:468
test/installer/test_installer.py:468
test/installer/test_installer.py:468
  /Users/justins/dev/github/aws-deadline/deadline-cloud-for-houdini/test/installer/test_installer.py:468: SyntaxWarning: invalid escape sequence '\*'
    """Assumes that the Windows SDK is installed so we can find signtool:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== slowest 5 durations ====================================================
12.87s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
12.82s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
12.38s setup    test/installer/test_installer.py::TestUserInstall::test_install
3.80s call     test/installer/test_installer.py::test_default_location
2.59s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
======================================== 4 passed, 9 skipped, 3 warnings in 16.32s =========================================
```
### Was this change documented?

N/A

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
