### PR TITLE
fix: remove tmp installer directory after install

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -217,6 +217,6 @@
             <destinationDirectory>${houdini_installdir}/python</destinationDirectory>
             <zipFile>${installdir}/tmp/houdini_deps/dependency_bundle/deadline_cloud_for_houdini_submitter-deps.zip</zipFile>
         </unzip>
-        <deleteFile path="${installdir}/tmp/houdini_deps"/>
+        <deleteFile path="${installdir}/tmp"/>
     </postInstallationActionList>
 </componentGroup>

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -185,6 +185,15 @@ def test_default_location(installer_path: Path):
         assert str(Path(location.group(1))) == str(default_install_location)
 
 
+@pytest.mark.parametrize("install_type", ["user_installation", "system_installation"])
+def test_tmp_directory_removed(install_type, request):
+    """Test that the temporary directory used during installation is removed."""
+    # GIVEN / WHEN / THEN
+    install_path = request.getfixturevalue(install_type)
+    tmp_dir = install_path / "tmp"
+    assert not tmp_dir.exists(), f"Temporary directory {tmp_dir} was not removed after installation"
+
+
 @pytest.mark.skipif(
     os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built with a license will not be evaluation mode",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
During the installation process, we create a `tmp` directory that is used to temporarily hold installation files. This isn't needed post installation but we fail to clean it up.

### What was the solution? (How)
Delete the `tmp` directory as a post installation action.

### What is the impact of this change?
Reduces unneeded files leftover after installation.

### How was this change tested?

- Have you run the unit tests?
  - No, this does not effect the unit tests.

#### Please run the integration tests and paste the results below.
```bash
========================================= test session starts =========================================
platform darwin -- Python 3.12.7, pytest-8.4.0, pluggy-1.6.0 -- /Users/justins/Library/Application Support/hatch/env/virtual/deadline-cloud-for-houdini/9wTjeyA9/deadline-cloud-for-houdini/bin/python
cachedir: .pytest_cache
rootdir: /Users/justins/dev/github/aws-deadline/deadline-cloud-for-houdini
configfile: pyproject.toml
plugins: xdist-3.7.0, cov-6.1.1
10 workers [15 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw5] [  6%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw6] [ 13%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw3] [ 20%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw3] [ 26%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw7] [ 33%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw0] [ 40%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 46%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw4] [ 53%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw4] [ 60%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw8] [ 66%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 73%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw2] [ 80%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw1] [ 86%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw1] [ 93%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

========================================= slowest 5 durations =========================================
18.96s call     test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
18.90s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
18.77s setup    test/installer/test_installer.py::TestUserInstall::test_install
18.38s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
14.77s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
==================================== 6 passed, 9 skipped in 22.03s ====================================

```
#### #### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

### Was this change documented?
N/A

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
