### PR TITLE
fix: System installs have no default path

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -29,13 +29,13 @@
                 </distributionDirectory>
             </distributionFileList>
             <actionList>
-                <setInstallerVariable name="deadline_package_file_name" value="deadline_submitter_for_houdini.json" />
+                <setInstallerVariable name="deadline_package_file_name" value="deadline_submitter_for_houdini.json"/>
                 <substitute>
                     <files>${houdini_packagedir}/${deadline_package_file_name}</files>
                     <type>exact</type>
                     <encoding>utf-8</encoding>
                     <substitutionList>
-                        <substitution pattern="INSTALL_DIR_PLACEHOLDER" value="${houdini_installdir.unix}" />
+                        <substitution pattern="INSTALL_DIR_PLACEHOLDER" value="${houdini_installdir.unix}"/>
                     </substitutionList>
                 </substitute>
                 <fnAddPathEnvironmentVariable>
@@ -95,10 +95,67 @@
                     <cliOptionName>houdini-19-5-package-dir</cliOptionName>
                     <cliOptionText>Path to the Houdini 19.5 packages directory. When the installer is run, if the HOUDINI_USER_PREF_DIR environment variable is set, this directory will default to the packages subdirectory at that path.</cliOptionText>
                     <mustBeWritable>yes</mustBeWritable>
+                    <!-- Do not show this parameter on Windows; we will just add the installation directory to HOUDINI_PACKAGE_DIR. -->
+                    <ruleList>
+                        <platformTest type="windows" negate="true"/>
+                    </ruleList>
+                    <!-- For non-Windows, choose an appropriate default based on install scope and OS -->
+                    <preShowPageActionList>
+                        <!-- User (any): Set based on user pref -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_19_5_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <setInstallerVariable name="houdini_19_5_packagedir" value="${houdini_user_pref_dir_default}19.5/packages"/>
+                            </actionList>
+                        </if>
+
+                        <!-- System (any): Set based on default Houdini location for the OS -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_19_5_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="system"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="linux" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_19_5_packagedir" value="/opt/hfs19.5/packages"/>
+                                    </actionList>
+                                </if>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_19_5_packagedir" value="/Applications/Houdini/Current/Frameworks/Houdini.framework/Versions/Current/Resources/packages"/>
+                                    </actionList>
+                                </if>
+                            </actionList>
+                        </if>
+                    </preShowPageActionList>
                 </directoryParameter>
             </parameterList>
             <postInstallationActionList>
-                <fnCopyHoudiniPackageFile destinationDir="${houdini_19_5_packagedir}" />
+                <!-- On Windows, we don't require copying the package file and can just set an environment variable.
+                For macOS and Linux, we must copy the file into the latest Houdini installation. -->
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="windows"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <fnAddPathEnvironmentVariable name="HOUDINI_PACKAGE_DIR" value="${houdini_packagedir}" scope="${installscope}"/>
+                    </actionList>
+                    <elseActionList>
+                        <fnCopyHoudiniPackageFile destinationDir="${houdini_19_5_packagedir}" />
+                    </elseActionList>
+                </if>
             </postInstallationActionList>
         </component>
         <component>
@@ -116,10 +173,67 @@
                     <cliOptionName>houdini-20-0-package-dir</cliOptionName>
                     <cliOptionText>Path to the Houdini 20.0 packages directory. When the installer is run, if the HOUDINI_USER_PREF_DIR environment variable is set, this directory will default to the packages subdirectory at that path.</cliOptionText>
                     <mustBeWritable>yes</mustBeWritable>
+                    <!-- Do not show this parameter on Windows; we will just add the installation directory to HOUDINI_PACKAGE_DIR. -->
+                    <ruleList>
+                        <platformTest type="windows" negate="true"/>
+                    </ruleList>
+                    <!-- For non-Windows, choose an appropriate default based on install scope and OS -->
+                    <preShowPageActionList>
+                        <!-- User (any): Set based on user pref -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_20_0_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <setInstallerVariable name="houdini_20_0_packagedir" value="${houdini_user_pref_dir_default}20.0/packages"/>
+                            </actionList>
+                        </if>
+
+                        <!-- System (any): Set based on default Houdini location for the OS -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_20_0_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="system"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="linux" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_20_0_packagedir" value="/opt/hfs20.0/packages"/>
+                                    </actionList>
+                                </if>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_20_0_packagedir" value="/Applications/Houdini/Current/Frameworks/Houdini.framework/Versions/Current/Resources/packages"/>
+                                    </actionList>
+                                </if>
+                            </actionList>
+                        </if>
+                    </preShowPageActionList>
                 </directoryParameter>
             </parameterList>
             <postInstallationActionList>
-                <fnCopyHoudiniPackageFile destinationDir="${houdini_20_0_packagedir}" />
+                <!-- On Windows, we don't require copying the package file and can just set an environment variable.
+                For macOS and Linux, we must copy the file into the latest Houdini installation. -->
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="windows"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <fnAddPathEnvironmentVariable name="HOUDINI_PACKAGE_DIR" value="${houdini_packagedir}" scope="${installscope}"/>
+                    </actionList>
+                    <elseActionList>
+                        <fnCopyHoudiniPackageFile destinationDir="${houdini_20_0_packagedir}" />
+                    </elseActionList>
+                </if>
             </postInstallationActionList>
         </component>
         <component>
@@ -131,22 +245,76 @@
                     <name>houdini_20_5_packagedir</name>
                     <description>Houdini 20.5 Packages Directory</description>
                     <explanation>Enter the path to the Houdini 20.5 packages directory. For easiest installation, Houdini should be installed before installing Deadline Cloud for Houdini.</explanation>
-                    <default>${houdini_user_pref_dir_default}20.5/packages</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
                     <cliOptionName>houdini-20-5-package-dir</cliOptionName>
                     <cliOptionText>Path to the Houdini 20.5 packages directory. When the installer is run, if the HOUDINI_USER_PREF_DIR environment variable is set, this directory will default to the packages subdirectory at that path.</cliOptionText>
                     <mustBeWritable>yes</mustBeWritable>
+                    <!-- Do not show this parameter on Windows; we will just add the installation directory to HOUDINI_PACKAGE_DIR. -->
+                    <ruleList>
+                        <platformTest type="windows" negate="true"/>
+                    </ruleList>
+                    <!-- For non-Windows, choose an appropriate default based on install scope and OS -->
+                    <preShowPageActionList>
+                        <!-- User (any): Set based on user pref -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_20_5_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <setInstallerVariable name="houdini_20_5_packagedir" value="${houdini_user_pref_dir_default}20.5/packages"/>
+                            </actionList>
+                        </if>
+
+                        <!-- System (any): Set based on default Houdini location for the OS -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_20_5_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="system"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="linux" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_20_5_packagedir" value="/opt/hfs20.5/packages" />
+                                    </actionList>
+                                </if>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_20_5_packagedir" value="/Applications/Houdini/Current/Frameworks/Houdini.framework/Versions/Current/Resources/packages"/>
+                                    </actionList>
+                                </if>
+                            </actionList>
+                        </if>
+                    </preShowPageActionList>
                 </directoryParameter>
             </parameterList>
             <postInstallationActionList>
-                <fnCopyHoudiniPackageFile destinationDir="${houdini_20_5_packagedir}" />
+                <!-- On Windows, we don't require copying the package file and can just set an environment variable.
+                For macOS and Linux, we must copy the file into the latest Houdini installation. -->
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="windows"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <fnAddPathEnvironmentVariable name="HOUDINI_PACKAGE_DIR" value="${houdini_packagedir}" scope="${installscope}"/>
+                    </actionList>
+                    <elseActionList>
+                        <fnCopyHoudiniPackageFile destinationDir="${houdini_20_5_packagedir}" />
+                    </elseActionList>
+                </if>
             </postInstallationActionList>
         </component>
     </componentList>
-    <initializationActionList>
-        <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_houdini" />
-        <if>
+    <preInitializationActionList><if>
             <conditionRuleList>
                 <compareText>
                     <text>${env(HOUDINI_USER_PREF_DIR)}</text>
@@ -184,10 +352,9 @@
                 <setInstallerVariable name="houdini_user_pref_dir_default" value="${user_home_directory}/Library/Preferences/houdini/" />
             </actionList>
         </if>
-        <!--To prevent conflicts we delete any copies of our package file in the old install locations-->
-        <deleteFile path="${houdini_user_pref_dir_default}19.5/packages/deadline_submitter_for_houdini.json" />
-        <deleteFile path="${houdini_user_pref_dir_default}20.0/packages/deadline_submitter_for_houdini.json" />
-        <deleteFile path="${houdini_user_pref_dir_default}20.5/packages/deadline_submitter_for_houdini.json" />
+    </preInitializationActionList>
+    <initializationActionList>
+        <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_houdini" />
     </initializationActionList>
     <readyToInstallActionList>
         <if>

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -68,6 +68,12 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         installation_path,
         "--enable-components",
         "deadline_cloud_for_houdini,houdini_19_5,houdini_20_0,houdini_20_5",
+        "--houdini-20-5-package-dir",
+        installation_path / "houdini19.5" / "packages",
+        "--houdini-20-0-package-dir",
+        installation_path / "houdini20.0" / "packages",
+        "--houdini-19-5-package-dir",
+        installation_path / "houdini20.5" / "packages",
     ]
     subprocess.run(args, check=True)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When installing the Houdini submitter system-wide, we don't provide an accurate default path for the package directory.

### What was the solution? (How)
Added new default options for package directories if `HOUDINI_PACKAGE_DIR` is not set:
- `/opt/hfs<MAJOR>.<MINOR>` on Linux (default Houdini installs symlink this to the latest patch version's directory)
- `/Applications/Houdini/Current/Frameworks/Houdini.framework/Versions/Current/Resources/packages` on macOS (only used in the individual installer)

Removed the parameter on Windows and re-added the environment variable solution, i.e., set/unset `HOUDINI_PACKAGE_DIR` to the install location on installation/uninstallation.

### What is the impact of this change?
Better UX for system installs on Linux/Windows

### How was this change tested?
- Ran the installer tests on both Windows and Linux
- Manually built/installed on Windows to make sure the environment variable solution still works

#### Please run the integration tests and paste the results below.
n/a, no submitter/adaptor changes

#### #### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
Windows:
```
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
test/installer/test_installer.py::TestWindows::test_user_permissions
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
[gw4] [  6%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_use
r_permissions
[gw3] [ 13%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_eva
luation_mode
test/installer/test_installer.py::TestVerifySigning::test_linux_signing
test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw4] [ 20%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_mac
os_signing
[gw3] [ 26%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_lin
ux_signing
test/installer/test_installer.py::TestWindows::test_system_permissions
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
test/installer/test_installer.py::TestUserInstall::test_uninstall
test/installer/test_installer.py::TestUserInstall::test_install
[gw7] [ 33%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_pe
rmissions
[gw5] [ 40%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_sys
tem_permissions
[gw0] [ 46%] PASSED test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestSystemInstall::test_install
[gw0] [ 53%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_ins
tall
[gw1] [ 60%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[u
ser_installation]
test/installer/test_installer.py::TestSystemInstall::test_uninstall
[gw1] [ 66%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uni
nstall
[gw8] [ 73%] PASSED test/installer/test_installer.py::TestUserInstall::test_instal
l
[gw2] [ 80%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[s
ystem_installation]
test/installer/test_installer.py::TestVerifySigning::test_windows_signing
[gw2] [ 86%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_win
dows_signing
[gw6] [ 93%] PASSED test/installer/test_installer.py::TestWindows::test_user_permi
ssions
[gw9] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninst
all

=============================== warnings summary ================================
test\installer\test_installer.py:483
  C:\Users\miabatta\GitHub\deadline-cloud-for-houdini\test\installer\test_installe
r.py:483: SyntaxWarning: invalid escape sequence '\*'
    """Assumes that the Windows SDK is installed so we can find signtool:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================== slowest 5 durations ==============================
176.78s call     test/installer/test_installer.py::test_tmp_directory_removed[syst
em_installation]
176.06s setup    test/installer/test_installer.py::TestUserInstall::test_install
175.94s call     test/installer/test_installer.py::test_tmp_directory_removed[user
_installation]
175.67s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
175.64s setup    test/installer/test_installer.py::TestWindows::test_user_permissi
ons
============== 6 passed, 9 skipped, 1 warning in 203.04s (0:03:23) ==============
```

Linux:
```
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
[gw7] [  6%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw6] [ 13%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw5] [ 20%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw5] [ 26%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw3] [ 33%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw6] [ 40%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw3] [ 46%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw0] [ 53%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 60%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw2] [ 66%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw1] [ 73%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw4] [ 80%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw4] [ 86%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 93%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw1] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

============================================================================================== slowest 5 durations ==============================================================================================
7.69s call     test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
7.64s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
7.62s setup    test/installer/test_installer.py::TestUserInstall::test_install
7.62s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
6.90s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
========================================================================================= 6 passed, 9 skipped in 16.18s =========================================================================================
```

### Was this change documented?
nop

### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
