### PR TITLE
chore: Remove default blocks for packages directory parameters

### DIFF
--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -89,7 +89,6 @@
                     <name>houdini_19_5_packagedir</name>
                     <description>Houdini 19.5 Packages Directory</description>
                     <explanation>Enter the path to the Houdini 19.5 packages directory. For easiest installation, Houdini should be installed before installing Deadline Cloud for Houdini.</explanation>
-                    <default>${houdini_user_pref_dir_default}19.5/packages</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
                     <cliOptionName>houdini-19-5-package-dir</cliOptionName>
@@ -167,7 +166,6 @@
                     <name>houdini_20_0_packagedir</name>
                     <description>Houdini 20.0 Packages Directory</description>
                     <explanation>Enter the path to the Houdini 20.0 packages directory. For easiest installation, Houdini should be installed before installing Deadline Cloud for Houdini.</explanation>
-                    <default>${houdini_user_pref_dir_default}20.0/packages</default>
                     <allowEmptyValue>0</allowEmptyValue>
                     <ask>yes</ask>
                     <cliOptionName>houdini-20-0-package-dir</cliOptionName>
@@ -314,7 +312,8 @@
             </postInstallationActionList>
         </component>
     </componentList>
-    <preInitializationActionList><if>
+    <preInitializationActionList>
+        <if>
             <conditionRuleList>
                 <compareText>
                     <text>${env(HOUDINI_USER_PREF_DIR)}</text>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Using `<default>` blocks overrides the logic we do to determine a reasonable default value for package directories. This means running a system install using the CLI still uses the wrong defaults.

### What was the solution? (How)
Removed the `<default>` blocks for the Houdini 19.5 and 20.0 submitter components.

Note that this means no "default" is shown in the CLI `--help` command, and you must still specify a parameter value on the command line.

### What is the impact of this change?
Better defaults when using the CLI installer

### How was this change tested?
- Manual testing running the installer on the command line (Linux)
- Ran the installer tests on Linux and Windows

#### Please run the integration tests and paste the results below.
n/a, no submitter/adaptor changes

#### #### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
Linux:
```
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw7] [  6%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw6] [ 13%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw5] [ 20%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw6] [ 26%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw5] [ 33%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
[gw3] [ 40%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw3] [ 46%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw0] [ 53%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 60%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw4] [ 66%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw4] [ 73%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw1] [ 80%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw1] [ 86%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 93%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

============================================================================================== slowest 5 durations ==============================================================================================
8.13s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
8.00s setup    test/installer/test_installer.py::TestUserInstall::test_install
7.94s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
7.86s call     test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
6.96s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
========================================================================================= 6 passed, 9 skipped in 16.46s =========================================================================================
```

Windows:
```
test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestUserInstall::test_install
test/installer/test_installer.py::TestWindows::test_user_permissions
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
test/installer/test_installer.py::TestWindows::test_system_permissions
test/installer/test_installer.py::TestUserInstall::test_uninstall
[gw4] [  6%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
[gw3] [ 13%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
[gw5] [ 20%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
[gw7] [ 26%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions
test/installer/test_installer.py::TestVerifySigning::test_macos_signing
test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw3] [ 33%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw4] [ 40%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw0] [ 46%] PASSED test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestSystemInstall::test_install
[gw0] [ 53%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install
[gw1] [ 60%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
test/installer/test_installer.py::TestSystemInstall::test_uninstall
[gw1] [ 66%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall
[gw2] [ 73%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
test/installer/test_installer.py::TestVerifySigning::test_windows_signing
[gw8] [ 80%] PASSED test/installer/test_installer.py::TestUserInstall::test_install
[gw2] [ 86%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing
[gw6] [ 93%] PASSED test/installer/test_installer.py::TestWindows::test_user_permissions
[gw9] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall

========================================================= slowest 5 durations ==========================================================
170.61s setup    test/installer/test_installer.py::TestWindows::test_user_permissions
170.61s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
170.60s setup    test/installer/test_installer.py::TestUserInstall::test_install
170.60s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
170.57s call     test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
=============================================== 6 passed, 9 skipped in 195.16s (0:03:15) ===============================================
```

### Was this change documented?
nop

### Is this a breaking change?
Using individual installers directly is not a recommended or supported workflow, so this is not a breaking change even though interaction with the individual installer has changed.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
