### PR TITLE
chore: Add timeouts to adaptor environment enter/exit actions

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -762,6 +762,7 @@ def get_houdini_environments(init_data_attachment: dict[str, Any]) -> list[dict[
                         "cancelation": {
                             "mode": "NOTIFY_THEN_TERMINATE",
                         },
+                        "timeout": 400,
                     },
                     "onExit": {
                         "command": "houdini-openjd",
@@ -774,6 +775,7 @@ def get_houdini_environments(init_data_attachment: dict[str, Any]) -> list[dict[
                         "cancelation": {
                             "mode": "NOTIFY_THEN_TERMINATE",
                         },
+                        "timeout": 120,
                     },
                 },
             },

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -37,6 +37,7 @@ steps:
           - file://{{ Env.File.initData }}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
         onExit:
           command: houdini-openjd
           args:
@@ -46,6 +47,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
   script:
     embeddedFiles:
     - name: runData

--- a/test/unit/deadline_submitter_for_houdini/test_job_template.py
+++ b/test/unit/deadline_submitter_for_houdini/test_job_template.py
@@ -119,6 +119,7 @@ def test_job_template(mock_get_steps, mock_parm):
                                         "file://{{ Env.File.initData }}",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 400,
                                 },
                                 "onExit": {
                                     "command": "houdini-openjd",
@@ -129,6 +130,7 @@ def test_job_template(mock_get_steps, mock_parm):
                                         "{{ Session.WorkingDirectory }}/connection.json",
                                     ],
                                     "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 120,
                                 },
                             },
                         },


### PR DESCRIPTION
Fixes: #224 

### What was the problem/requirement? (What/Why)
There is an edge case where the Houdini adaptor can get stuck launching before the worker agent can enforce its timeout, which will cause Houdini to hang indefinitely.

### What was the solution? (How)
- Added `timeout` attributes to the Houdini adaptor `envEnter` and `envExit` actions. These are based off the [Houdini server timeouts](https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/8d9cbd420331cb761a12bb4b069cc0412d4b2868/src/deadline/houdini_adaptor/HoudiniAdaptor/adaptor.py#L64-L67) so the environment will not timeout before these do
  - Enter timeout: 400 seconds (300 + 30 + an extra ~minute)
  - Exit timeout: 120 seconds (30 + 30 + extra minute)
- Refactored unit/integ tests to add the timeout attributes

### What is the impact of this change?
We observed the adaptor hanging behaviour in other DCCs which is scary. Now we can be proactive about preventing them in Houdini!

### How was this change tested?
- Unit & integration tests

#### Please run the integration tests and paste the results below.
```test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter

================================================= slowest 5 durations =================================================
10.92s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s teardown test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
================================================= 1 passed in 11.81s ==================================================
```
#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
n/a

### Was this change documented?
not required

### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
