### PR TITLE
chore: fix sematic versioning to allow for zero versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ fail_under = 65
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Semantic versioning recently had a change where they no longer allow zero versions unless a flag is set, a change from previous behavior.

### What was the solution? (How)
Add the flag to allow zero versions.

### What is the impact of this change?
Automated versioning works again.

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
