### PR TITLE
test(integ): Add submitter test with wedge node

### DIFF
--- a/test/integ/test_houdini_submitters.py
+++ b/test/integ/test_houdini_submitters.py
@@ -16,6 +16,55 @@ class TestSubmitters:
     Tests that the Houdini submitter generates the job bundle we expect given different scenes & parameters.
     """
 
+    """
+    Helpers
+    """
+
+    def _assert_job_template(
+        self, scene_location_posix, expected_job_template_dir, job_history_dir
+    ):
+        with (
+            open(expected_job_template_dir / "template.yaml") as expected,
+            open(job_history_dir / "template.yaml") as actual,
+        ):
+
+            # Inject the scene location and Houdini version.
+            # These are the only variables that can change depending on the user's test environment.
+            expected_template = yaml.safe_load(expected)
+            expected_template["parameterDefinitions"][0]["default"] = scene_location_posix
+
+            for step in expected_template["steps"]:
+                init_data_file = step["stepEnvironments"][0]["script"]["embeddedFiles"][0]
+                init_data_file["data"] = init_data_file["data"].replace(
+                    "<HOUDINI_VERSION>", os.environ["HOUDINI_VERSION"]
+                )
+
+            assert expected_template == yaml.safe_load(actual)
+
+    def _assert_parameter_values(self, job_history_dir: Path, expected_params: dict[str, list]):
+        with open(job_history_dir / "parameter_values.yaml") as actual:
+            actual_params = yaml.safe_load(actual)
+            assert len(actual_params["parameterValues"]) == len(expected_params["parameterValues"])
+            for param_value in expected_params["parameterValues"]:
+                assert param_value in actual_params["parameterValues"]
+
+    def _assert_asset_references(
+        self, job_history_dir: Path, expected_asset_references: dict[str, dict[str, Any]]
+    ):
+        with open(job_history_dir / "asset_references.yaml") as actual:
+            actual_asset_references = yaml.safe_load(actual)
+            assert len(actual_asset_references["assetReferences"]["inputs"]["filenames"]) == len(
+                expected_asset_references["assetReferences"]["inputs"]["filenames"]
+            )
+            actual_asset_references["assetReferences"]["inputs"]["filenames"] = set(
+                actual_asset_references["assetReferences"]["inputs"]["filenames"]
+            )
+            assert actual_asset_references == expected_asset_references
+
+    """
+    Test Cases
+    """
+
     def test_minimal_scene_submitter(
         self,
         hython_location: Path,
@@ -48,26 +97,12 @@ class TestSubmitters:
         # Covert the path to POSIX, which is Houdini's convention on any OS
         scene_location_posix = scene_location.as_posix()
 
-        with (
-            open(
-                script_location / "minimal_test" / "expected_job_bundle" / "template.yaml"
-            ) as expected,
-            open(job_history_dir / "template.yaml") as actual,
-        ):
-
-            # Inject the scene location and Houdini version.
-            # These are the only variables that can change depending on the user's test environment.
-            expected_template = yaml.safe_load(expected)
-            expected_template["parameterDefinitions"][0]["default"] = scene_location_posix
-
-            init_data_file = expected_template["steps"][0]["stepEnvironments"][0]["script"][
-                "embeddedFiles"
-            ][0]
-            init_data_file["data"] = init_data_file["data"].replace(
-                "<HOUDINI_VERSION>", os.environ["HOUDINI_VERSION"]
-            )
-
-            assert expected_template == yaml.safe_load(actual)
+        # We need to inject submitter information into the expected job bundle before comparing
+        self._assert_job_template(
+            scene_location.as_posix(),
+            script_location / "minimal_test" / "expected_job_bundle",
+            job_history_dir,
+        )
 
         # Check that the parameter values are as expected
         expected_params: dict[str, list] = {
@@ -79,12 +114,7 @@ class TestSubmitters:
                 {"name": "deadline:targetTaskRunStatus", "value": "READY"},
             ]
         }
-
-        with open(job_history_dir / "parameter_values.yaml") as actual:
-            actual_params = yaml.safe_load(actual)
-            assert len(actual_params["parameterValues"]) == len(expected_params["parameterValues"])
-            for param_value in expected_params["parameterValues"]:
-                assert param_value in actual_params["parameterValues"]
+        self._assert_parameter_values(job_history_dir, expected_params)
 
         # Check that the asset references are as expected
         expected_asset_references: dict[str, dict[str, Any]] = {
@@ -98,13 +128,65 @@ class TestSubmitters:
                 "referencedPaths": [],
             }
         }
+        self._assert_asset_references(job_history_dir, expected_asset_references)
 
-        with open(job_history_dir / "asset_references.yaml") as actual:
-            actual_asset_references = yaml.safe_load(actual)
-            assert len(actual_asset_references["assetReferences"]["inputs"]["filenames"]) == len(
-                expected_asset_references["assetReferences"]["inputs"]["filenames"]
-            )
-            actual_asset_references["assetReferences"]["inputs"]["filenames"] = set(
-                actual_asset_references["assetReferences"]["inputs"]["filenames"]
-            )
-            assert actual_asset_references == expected_asset_references
+    def test_wedge_node_submitter(
+        self, hython_location: Path, script_location: Path, tmp_path: Path
+    ):
+        job_history_dir = tmp_path / "jobhistory"
+        output_path = tmp_path / "output"
+
+        os.makedirs(job_history_dir, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
+
+        output = run_houdini_submitter_test(
+            hython_location,
+            script_location / "wedge_node_test" / "_test_hip.py",
+            str(job_history_dir),
+            str(output_path),
+            "submitter",
+        )
+
+        assert (
+            output.returncode == 0
+        ), f"Houdini submitter exited with code {output.returncode}:\n{output.stderr.decode(encoding='utf-8', errors='replace')}"
+        # Check that we have a valid template
+        assert is_valid_template(job_history_dir / "template.yaml")
+
+        # Houdini will save the HIP file as an absolute path, so we have to inject it into the expected template & parameter values.
+        scene_location = Path.cwd() / "test_wedge.hip"
+        # Covert the path to POSIX, which is Houdini's convention on any OS
+        scene_location_posix = scene_location.as_posix()
+
+        # We need to inject submitter information into the expected job bundle before comparing
+        self._assert_job_template(
+            scene_location.as_posix(),
+            script_location / "wedge_node_test" / "expected_job_bundle",
+            job_history_dir,
+        )
+
+        # Check that the parameter values are as expected
+        expected_params: dict[str, list] = {
+            "parameterValues": [
+                {"name": "HipFile", "value": scene_location_posix},
+                {"name": "deadline:priority", "value": 50},
+                {"name": "deadline:maxRetriesPerTask", "value": 5},
+                {"name": "deadline:maxFailedTasksCount", "value": 20},
+                {"name": "deadline:targetTaskRunStatus", "value": "READY"},
+            ]
+        }
+        self._assert_parameter_values(job_history_dir, expected_params)
+
+        # Check that the asset references are as expected
+        expected_asset_references: dict[str, dict[str, Any]] = {
+            "assetReferences": {
+                "inputs": {"directories": [], "filenames": {scene_location_posix}},
+                "outputs": {
+                    "directories": [
+                        str(output_path) + "/render"
+                    ],  # The test scene uses a forward slash for the render directory
+                },
+                "referencedPaths": [],
+            }
+        }
+        self._assert_asset_references(job_history_dir, expected_asset_references)

--- a/test/integ/test_scripts/wedge_node_test/_test_hip.py
+++ b/test/integ/test_scripts/wedge_node_test/_test_hip.py
@@ -1,0 +1,153 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import argparse
+import sys
+from pathlib import Path
+
+import hou
+from deadline_cloud_for_houdini._assets import (  # type: ignore
+    _get_evaluated_asset_references,
+    _parse_files,
+)
+from deadline_cloud_for_houdini.submitter import _create_job_bundle  # type: ignore
+
+
+def _create_material_node() -> hou.VopNode:
+    """
+    Create a material node to use as a wedge channel.
+    """
+    mat_node = hou.node("/mat").createNode("tooncolorshader", "tooncolorshader1")
+
+    mat_node.parm("colorhighr").set(0.771)
+    mat_node.parm("colorhighg").set(0.279)
+    mat_node.parm("colorhighb").set(0.411)
+
+    mat_node.parm("colormidr").set(0)
+    mat_node.parm("colormidg").set(0.5)
+    mat_node.parm("colormidb").set(1)
+
+    mat_node.parm("colorlowr").set(0.314667)
+    mat_node.parm("colorlowg").set(-0.129333)
+    mat_node.parm("colorlowb").set(0.564667)
+
+    return mat_node
+
+
+def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
+    """
+    Uses the Houdini API to create nodes comprising a simple scene.
+    """
+
+    hou.hipFile.setName("test_wedge.hip")
+
+    geo_node = hou.node("/obj").createNode("geo", "test_geometry")
+    geo_node.createNode("box", "test_box")
+    geo_node.parm("shop_materialpath").set("/mat/tooncolorshader1")
+
+    cam_node = hou.node("/obj").createNode("cam", "test_cam")
+    light_node = hou.node("/obj").createNode("hlight", "test_light")
+
+    # Translate & rotate the camera back to capture the box
+    cam_translate = hou.hmath.buildTranslate(5, 5, 5)
+    cam_node.setParmTransform(cam_translate)
+    cam_node.setWorldTransform(cam_node.buildLookatRotation(geo_node))
+
+    # Translate the light to visibly shade the box
+    light_translate = hou.hmath.buildTranslate(1, 1, 2)
+    light_node.setParmTransform(light_translate)
+
+    # To create two distinct frames, we will move the camera.
+    # This requires creating keyframes on the camera's transform
+    cam_tx = hou.parm("/obj/test_cam/tx")
+    cam_frame1 = hou.Keyframe()
+    cam_frame1.setFrame(1)
+    cam_frame1.setValue(5)
+
+    cam_frame2 = hou.Keyframe()
+    cam_frame2.setFrame(2)
+    cam_frame2.setValue(5.5)
+
+    cam_tx.setKeyframes((cam_frame1, cam_frame2))
+
+    render_node = hou.node("/out").createNode("ifd")
+
+    # Set the render node to use the camera we just created
+    render_node.parm("camera").set(cam_node.path())
+    render_node.parm("vm_picture").set(f"{output_dir}/render/$HIPNAME.$OS.$WEDGE.$WEDGENUM.$F4.png")
+    render_node.parm("soho_mkpath").set(1)  # Set intermediate directories
+
+    return render_node
+
+
+def _create_wedge_node() -> hou.RopNode:
+    """
+    Place a wedge node in the /out network and give it the parameters we expect.
+    """
+    wedge_node = hou.node("/out").createNode("wedge")
+    wedge_node.parm("random").set(0)
+    wedge_node.parm("driver").set("/out/mantra1")
+
+    # Create one wedge parameter using the material node as a channel
+    wedge_node.parm("wedgeparams").set(1)
+
+    wedge_node.parm("name1").set("wedge_colour_midr")
+    wedge_node.parm("chan1").set("../../mat/tooncolorshader1/colormidr")
+    wedge_node.parm("range1x").set(0)
+    wedge_node.parm("range1y").set(1)
+    wedge_node.parm("steps1").set(2)
+
+    return wedge_node
+
+
+def _set_parameters(submitter_node: hou.Node):
+    """
+    Set scene parameters in the submitter to create the template we expect.
+    """
+    submitter_node.parm("name").set("$HIPNAME")
+    submitter_node.parm("description").set("Wedge")
+    submitter_node.parm("separate_steps").set(1)
+    submitter_node.parm("include_adaptor_wheels").set(0)
+    submitter_node.parm("auto_unlock_rops").set(0)
+    submitter_node.parm("auto_parse_hip").set(0)
+    submitter_node.parm("auto_save_hip").set(0)
+
+    # Set the frame range
+    submitter_node.parm("trange").set(
+        2
+    )  # This is an enum dropdown. 2 corresponds to the "Render Frame Range" option.
+    hou.playbar.setFrameRange(1, 2)
+
+
+def _build_scene(output_dir: str) -> None:
+    _create_material_node()
+    _create_scene_and_rop(output_dir)
+    wedge_node = _create_wedge_node()
+    submitter_node = hou.node("/out").createNode("deadline_cloud")
+
+    submitter_node.setFirstInput(wedge_node)
+    _set_parameters(submitter_node)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("job_history_dir")
+    parser.add_argument("output_dir")
+    parser.add_argument("test_type", type=str, choices=["submitter", "adaptor"])
+    args = parser.parse_args(args=sys.argv[sys.argv.index("--") :])
+
+    # We want to use the same scene for both submitter and adaptor tests.
+    # Depending on which test, we have different uses for the scene file:
+    # Either use the submitter node to generate a job bundle,
+    # or save the scene for use in an `openjd run` call.
+    _build_scene(args.output_dir)
+
+    if args.test_type == "submitter":
+        submitter_node = hou.node("/out/deadline_cloud1")
+        _parse_files(submitter_node)
+        _create_job_bundle(
+            submitter_node,
+            args.job_history_dir,
+            _get_evaluated_asset_references(submitter_node),
+        )
+    elif args.test_type == "adaptor":
+        hou.hipFile.save(str(Path(args.output_dir).joinpath(hou.hipFile.basename())))

--- a/test/integ/test_scripts/wedge_node_test/expected_job_bundle/asset_references.yaml
+++ b/test/integ/test_scripts/wedge_node_test/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,7 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames: {}
+  outputs:
+    directories: []
+  referencedPaths: []

--- a/test/integ/test_scripts/wedge_node_test/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scripts/wedge_node_test/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,11 @@
+parameterValues:
+- name: deadline:priority
+  value: 50
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: HipFile
+  value: <HIP_LOCATION>/test_wedge.hip

--- a/test/integ/test_scripts/wedge_node_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/wedge_node_test/expected_job_bundle/template.yaml
@@ -1,0 +1,150 @@
+specificationVersion: jobtemplate-2023-09
+name: test_wedge
+parameterDefinitions:
+- name: HipFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  default: <HIP_LOCATION>/test_wedge.hip
+steps:
+- name: /out/mantra1-1-_wedge-0
+  stepEnvironments:
+  - name: Houdini
+    description: Runs Houdini in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          ignore_input_nodes: true
+          render_node: /out/mantra1
+          scene_file: '{{Param.HipFile}}'
+          version: <HOUDINI_VERSION>
+          wedge_node: /out/wedge1
+          wedgenum: '0'
+      actions:
+        onEnter:
+          command: houdini-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
+        onExit:
+          command: houdini-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame_range:
+          end: {{Task.Param.Frame}}
+          start: {{Task.Param.Frame}}
+          step: 1
+        ignore_input_nodes: true
+        render_node: /out/mantra1
+    actions:
+      onRun:
+        command: houdini-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      range: 1-1:1
+      type: INT
+- name: /out/mantra1-1-_wedge-1
+  stepEnvironments:
+  - name: Houdini
+    description: Runs Houdini in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          ignore_input_nodes: true
+          render_node: /out/mantra1
+          scene_file: '{{Param.HipFile}}'
+          version: <HOUDINI_VERSION>
+          wedge_node: /out/wedge1
+          wedgenum: '1'
+      actions:
+        onEnter:
+          command: houdini-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
+        onExit:
+          command: houdini-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame_range:
+          end: {{Task.Param.Frame}}
+          start: {{Task.Param.Frame}}
+          step: 1
+        ignore_input_nodes: true
+        render_node: /out/mantra1
+    actions:
+      onRun:
+        command: houdini-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      range: 1-1:1
+      type: INT
+description: Wedge


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want more comprehensive integ tests!

### What was the solution? (How)
Add a submitter test for a scene with a wedge node.
- Added a new folder in `test_scripts` , `wedge_node_test`
- Wrote a script to build a scene with a material node & wedge node that uses it
- Added the new test case to `test_houdini_submitters.py`
- Refactored some common code out of the minimal test case

### What is the impact of this change?
More robust integration tests

### How was this change tested?
Reran unit tests to check for regressions, ran this integration test on Linux and Windows

#### Please run the integration tests and paste the results below.
Windows:
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter

================================================= slowest 5 durations =================================================
54.73s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
10.15s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
10.07s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
0.01s setup    test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
============================================ 3 passed in 75.93s (0:01:15) =============================================
```
Linux:
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 

============================= slowest 5 durations ==============================
26.87s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
3.55s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
3.32s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
0.00s setup    test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
============================== 3 passed in 34.20s ==============================

```

### Was this change documented?
nop

### Is this a breaking change?
nop
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
