### PR TITLE
test(integ): Add submitter test with render dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-houdini/
 
 #### Please run the integration tests and paste the results below.
 
-#### #### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
+#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
 
 ### Was this change documented?
 

--- a/test/integ/test_houdini_submitters.py
+++ b/test/integ/test_houdini_submitters.py
@@ -66,11 +66,16 @@ class TestSubmitters:
     """
 
     def test_minimal_scene_submitter(
-        self,
-        hython_location: Path,
-        script_location: Path,
-        tmp_path: Path,
+        self, hython_location: Path, script_location: Path, tmp_path: Path
     ) -> None:
+        """
+        Tests a basic scene with one render node and two frames.
+        This generates:
+        - a job template with one step and a task parameter
+        - the HIP filename as a job parameter
+        - the HIP filename and output directory in asset references
+        """
+
         job_history_dir = tmp_path / "jobhistory"
         output_path = tmp_path / "output"
 
@@ -133,6 +138,14 @@ class TestSubmitters:
     def test_wedge_node_submitter(
         self, hython_location: Path, script_location: Path, tmp_path: Path
     ):
+        """
+        Tests a basic scene with a material wedge node and one render node.
+        This generates:
+        - a job template with two steps, one per wedge parameter, with two frames each
+        - the HIP filename as a job parameter
+        - the HIP filename and output directory as asset references
+        """
+
         job_history_dir = tmp_path / "jobhistory"
         output_path = tmp_path / "output"
 
@@ -182,9 +195,7 @@ class TestSubmitters:
             "assetReferences": {
                 "inputs": {"directories": [], "filenames": {scene_location_posix}},
                 "outputs": {
-                    "directories": [
-                        str(output_path) + "/render"
-                    ],  # The test scene uses a forward slash for the render directory
+                    "directories": [str(output_path) + "/render"],
                 },
                 "referencedPaths": [],
             }
@@ -197,6 +208,15 @@ class TestSubmitters:
         script_location: Path,
         tmp_path: Path,
     ) -> None:
+        """
+        Tests a basic scene with two render nodes chained together.
+        This generates:
+        - a job template with two steps, one dependent on the other; each step has two tasks
+        - the HIP filename as a job parameter
+        - the HIP filename and output directory as asset references
+        """
+        scene_name = "test_render_deps.hip"
+
         job_history_dir = tmp_path / "jobhistory"
         output_path = tmp_path / "output"
 
@@ -208,6 +228,7 @@ class TestSubmitters:
             script_location / "render_dependencies_test" / "_test_hip.py",
             str(job_history_dir),
             str(output_path),
+            scene_name,
             "submitter",
         )
 
@@ -216,7 +237,7 @@ class TestSubmitters:
         ), f"Houdini submitter exited with code {output.returncode}:\n{output.stderr.decode(encoding='utf-8', errors='replace')}"
         assert is_valid_template(job_history_dir / "template.yaml")
 
-        scene_location = Path.cwd() / "test_render_deps.hip"
+        scene_location = Path.cwd() / scene_name
         scene_location_posix = scene_location.as_posix()
 
         self._assert_job_template(
@@ -245,9 +266,7 @@ class TestSubmitters:
                     },
                 },
                 "outputs": {
-                    "directories": [
-                        str(output_path) + "/render"
-                    ],  # The test scene uses a forward slash for the render directory
+                    "directories": [str(output_path)],
                 },
                 "referencedPaths": [],
             }

--- a/test/integ/test_houdini_submitters.py
+++ b/test/integ/test_houdini_submitters.py
@@ -190,3 +190,66 @@ class TestSubmitters:
             }
         }
         self._assert_asset_references(job_history_dir, expected_asset_references)
+
+    def test_render_dependencies_submitter(
+        self,
+        hython_location: Path,
+        script_location: Path,
+        tmp_path: Path,
+    ) -> None:
+        job_history_dir = tmp_path / "jobhistory"
+        output_path = tmp_path / "output"
+
+        os.makedirs(job_history_dir, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
+
+        output = run_houdini_submitter_test(
+            hython_location,
+            script_location / "render_dependencies_test" / "_test_hip.py",
+            str(job_history_dir),
+            str(output_path),
+            "submitter",
+        )
+
+        assert (
+            output.returncode == 0
+        ), f"Houdini submitter exited with code {output.returncode}:\n{output.stderr.decode(encoding='utf-8', errors='replace')}"
+        assert is_valid_template(job_history_dir / "template.yaml")
+
+        scene_location = Path.cwd() / "test_render_deps.hip"
+        scene_location_posix = scene_location.as_posix()
+
+        self._assert_job_template(
+            scene_location_posix,
+            script_location / "render_dependencies_test" / "expected_job_bundle",
+            job_history_dir,
+        )
+
+        expected_params: dict[str, list] = {
+            "parameterValues": [
+                {"name": "HipFile", "value": scene_location_posix},
+                {"name": "deadline:priority", "value": 50},
+                {"name": "deadline:maxRetriesPerTask", "value": 5},
+                {"name": "deadline:maxFailedTasksCount", "value": 20},
+                {"name": "deadline:targetTaskRunStatus", "value": "READY"},
+            ]
+        }
+        self._assert_parameter_values(job_history_dir, expected_params)
+
+        expected_asset_reference: dict[str, dict[str, Any]] = {
+            "assetReferences": {
+                "inputs": {
+                    "directories": [],
+                    "filenames": {
+                        scene_location_posix,
+                    },
+                },
+                "outputs": {
+                    "directories": [
+                        str(output_path) + "/render"
+                    ],  # The test scene uses a forward slash for the render directory
+                },
+                "referencedPaths": [],
+            }
+        }
+        self._assert_asset_references(job_history_dir, expected_asset_reference)

--- a/test/integ/test_scripts/render_dependencies_test/_test_hip.py
+++ b/test/integ/test_scripts/render_dependencies_test/_test_hip.py
@@ -17,8 +17,6 @@ def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
     Uses the Houdini API to create nodes comprising a simple scene.
     """
 
-    hou.hipFile.setName("test_render_deps.hip")
-
     geo_node = hou.node("/obj").createNode("geo", "test_geometry")
     geo_node.createNode("box", "test_box")
 
@@ -67,11 +65,11 @@ def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
 
     # Set the render node to use the camera we just created
     render_node1.parm("camera").set(cam_node1.path())
-    render_node1.parm("vm_picture").set(f"{output_dir}/render/$HIPNAME.$OS.$F4.png")
+    render_node1.parm("vm_picture").set(f"{output_dir}/$HIPNAME.$OS.$F4.png")
     render_node1.parm("soho_mkpath").set(1)  # Set intermediate directories
 
     render_node2.parm("camera").set(cam_node2.path())
-    render_node2.parm("vm_picture").set(f"{output_dir}/render/$HIPNAME.$OS.$F4.png")
+    render_node2.parm("vm_picture").set(f"{output_dir}/$HIPNAME.$OS.$F4.png")
     render_node2.parm("soho_mkpath").set(1)  # Set intermediate directories
 
     # Create a dependency by chaining the render nodes
@@ -99,7 +97,8 @@ def _set_parameters(submitter_node: hou.Node):
     hou.playbar.setFrameRange(1, 2)
 
 
-def _build_scene(output_dir: str) -> None:
+def _build_scene(output_dir: str, scene_name: str) -> None:
+    hou.hipFile.setName(scene_name)
     final_render_node = _create_scene_and_rop(output_dir)
     submitter_node = hou.node("/out").createNode("deadline_cloud")
 
@@ -111,6 +110,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("job_history_dir")
     parser.add_argument("output_dir")
+    parser.add_argument("scene_name")
     parser.add_argument("test_type", type=str, choices=["submitter", "adaptor"])
     args = parser.parse_args(args=sys.argv[sys.argv.index("--") :])
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     # Depending on which test, we have different uses for the scene file:
     # Either use the submitter node to generate a job bundle,
     # or save the scene for use in an `openjd run` call.
-    _build_scene(args.output_dir)
+    _build_scene(args.output_dir, args.scene_name)
 
     if args.test_type == "submitter":
         submitter_node = hou.node("/out/deadline_cloud1")

--- a/test/integ/test_scripts/render_dependencies_test/_test_hip.py
+++ b/test/integ/test_scripts/render_dependencies_test/_test_hip.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import argparse
+import sys
+from pathlib import Path
+
+import hou
+from deadline_cloud_for_houdini._assets import (  # type: ignore
+    _get_evaluated_asset_references,
+    _parse_files,
+)
+from deadline_cloud_for_houdini.submitter import _create_job_bundle  # type: ignore
+
+
+def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
+    """
+    Uses the Houdini API to create nodes comprising a simple scene.
+    """
+
+    hou.hipFile.setName("test_render_deps.hip")
+
+    geo_node = hou.node("/obj").createNode("geo", "test_geometry")
+    geo_node.createNode("box", "test_box")
+
+    # Create two distinct cameras to merge them together afterwards
+    cam_node1 = hou.node("/obj").createNode("cam", "test_cam")
+    cam_node2 = hou.node("/obj").createNode("cam", "test_cam2")
+
+    light_node = hou.node("/obj").createNode("hlight", "test_light")
+
+    # Camera transformations
+    cam_node1.setParmTransform(hou.hmath.buildTranslate(5, 5, 5))
+    cam_node1.setWorldTransform(cam_node1.buildLookatRotation(geo_node))
+    cam_node2.setParmTransform(hou.hmath.buildTranslate(5, 2, 0))
+    cam_node2.setWorldTransform(cam_node2.buildLookatRotation(geo_node))
+
+    # Translate the light to visibly shade the box
+    light_translate = hou.hmath.buildTranslate(1, 1, 2)
+    light_node.setParmTransform(light_translate)
+
+    # To create two distinct frames, we will move the camera.
+    # This requires creating keyframes on the camera's transform
+    cam_tx1 = hou.parm("/obj/test_cam/tx")
+    cam1_frame1 = hou.Keyframe()
+    cam1_frame1.setFrame(1)
+    cam1_frame1.setValue(5)
+
+    cam1_frame2 = hou.Keyframe()
+    cam1_frame2.setFrame(2)
+    cam1_frame2.setValue(5.5)
+
+    cam_tx1.setKeyframes((cam1_frame1, cam1_frame2))
+
+    cam_tx2 = hou.parm("/obj/test_cam2/tx")
+    cam2_frame1 = hou.Keyframe()
+    cam2_frame1.setFrame(1)
+    cam2_frame1.setValue(5)
+
+    cam2_frame2 = hou.Keyframe()
+    cam2_frame2.setFrame(2)
+    cam2_frame2.setValue(5.5)
+
+    cam_tx2.setKeyframes((cam2_frame1, cam2_frame2))
+
+    render_node1 = hou.node("/out").createNode("ifd")
+    render_node2 = hou.node("/out").createNode("ifd")
+    merge_node = hou.node("/out").createNode("merge", "merge_node")
+    merge_node.setFirstInput(render_node1)
+    merge_node.setNextInput(render_node2)
+
+    # Set the render node to use the camera we just created
+    render_node1.parm("camera").set(cam_node1.path())
+    render_node1.parm("vm_picture").set(f"{output_dir}/render/$HIPNAME.$OS.$F4.png")
+    render_node1.parm("soho_mkpath").set(1)  # Set intermediate directories
+
+    render_node2.parm("camera").set(cam_node2.path())
+    render_node2.parm("vm_picture").set(f"{output_dir}/render/$HIPNAME.$OS.$F4.png")
+    render_node2.parm("soho_mkpath").set(1)  # Set intermediate directories
+
+    return render_node1
+
+
+def _set_parameters(submitter_node: hou.Node):
+    """
+    Set scene parameters in the submitter to create the template we expect.
+    """
+    submitter_node.parm("name").set("$HIPNAME")
+    submitter_node.parm("description").set("Render dependencies")
+    submitter_node.parm("separate_steps").set(1)
+    submitter_node.parm("include_adaptor_wheels").set(0)
+    submitter_node.parm("auto_unlock_rops").set(0)
+    submitter_node.parm("auto_parse_hip").set(0)
+    submitter_node.parm("auto_save_hip").set(0)
+
+    # Set the frame range
+    submitter_node.parm("trange").set(
+        2
+    )  # This is an enum dropdown. 2 corresponds to the "Render Frame Range" option.
+    hou.playbar.setFrameRange(1, 2)
+
+
+def _build_scene(output_dir: str) -> None:
+    _create_scene_and_rop(output_dir)
+    submitter_node = hou.node("/out").createNode("deadline_cloud")
+
+    submitter_node.setFirstInput(hou.node("/out/merge_node"))
+    _set_parameters(submitter_node)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("job_history_dir")
+    parser.add_argument("output_dir")
+    parser.add_argument("test_type", type=str, choices=["submitter", "adaptor"])
+    args = parser.parse_args(args=sys.argv[sys.argv.index("--") :])
+
+    # We want to use the same scene for both submitter and adaptor tests.
+    # Depending on which test, we have different uses for the scene file:
+    # Either use the submitter node to generate a job bundle,
+    # or save the scene for use in an `openjd run` call.
+    _build_scene(args.output_dir)
+
+    if args.test_type == "submitter":
+        submitter_node = hou.node("/out/deadline_cloud1")
+        _parse_files(submitter_node)
+        _create_job_bundle(
+            submitter_node,
+            args.job_history_dir,
+            _get_evaluated_asset_references(submitter_node),
+        )
+    elif args.test_type == "adaptor":
+        hou.hipFile.save(str(Path(args.output_dir).joinpath(hou.hipFile.basename())))

--- a/test/integ/test_scripts/render_dependencies_test/_test_hip.py
+++ b/test/integ/test_scripts/render_dependencies_test/_test_hip.py
@@ -22,7 +22,7 @@ def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
     geo_node = hou.node("/obj").createNode("geo", "test_geometry")
     geo_node.createNode("box", "test_box")
 
-    # Create two distinct cameras to merge them together afterwards
+    # Create two distinct cameras for our render nodes
     cam_node1 = hou.node("/obj").createNode("cam", "test_cam")
     cam_node2 = hou.node("/obj").createNode("cam", "test_cam2")
 
@@ -64,9 +64,6 @@ def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
 
     render_node1 = hou.node("/out").createNode("ifd")
     render_node2 = hou.node("/out").createNode("ifd")
-    merge_node = hou.node("/out").createNode("merge", "merge_node")
-    merge_node.setFirstInput(render_node1)
-    merge_node.setNextInput(render_node2)
 
     # Set the render node to use the camera we just created
     render_node1.parm("camera").set(cam_node1.path())
@@ -77,7 +74,10 @@ def _create_scene_and_rop(output_dir: str) -> hou.RopNode:
     render_node2.parm("vm_picture").set(f"{output_dir}/render/$HIPNAME.$OS.$F4.png")
     render_node2.parm("soho_mkpath").set(1)  # Set intermediate directories
 
-    return render_node1
+    # Create a dependency by chaining the render nodes
+    render_node2.setFirstInput(render_node1)
+
+    return render_node2
 
 
 def _set_parameters(submitter_node: hou.Node):
@@ -100,10 +100,10 @@ def _set_parameters(submitter_node: hou.Node):
 
 
 def _build_scene(output_dir: str) -> None:
-    _create_scene_and_rop(output_dir)
+    final_render_node = _create_scene_and_rop(output_dir)
     submitter_node = hou.node("/out").createNode("deadline_cloud")
 
-    submitter_node.setFirstInput(hou.node("/out/merge_node"))
+    submitter_node.setFirstInput(final_render_node)
     _set_parameters(submitter_node)
 
 

--- a/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/asset_references.yaml
+++ b/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/asset_references.yaml
@@ -1,0 +1,7 @@
+assetReferences:
+  inputs:
+    directories: []
+    filenames: []
+  outputs:
+    directories: []
+  referencedPaths: []

--- a/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/parameter_values.yaml
@@ -1,0 +1,11 @@
+parameterValues:
+- name: deadline:priority
+  value: 50
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: HipFile
+  value: <HIP_LOCATION>/test_render_deps.hip

--- a/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/template.yaml
@@ -1,0 +1,150 @@
+specificationVersion: jobtemplate-2023-09
+name: test_render_deps
+parameterDefinitions:
+- name: HipFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  default: <HIP_LOCATION>/test_render_deps.hip
+steps:
+- name: /out/mantra1-1
+  stepEnvironments:
+  - name: Houdini
+    description: Runs Houdini in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          ignore_input_nodes: true
+          render_node: /out/mantra1
+          scene_file: '{{Param.HipFile}}'
+          version: <HOUDINI_VERSION>
+          wedge_node: ''
+          wedgenum: ''
+      actions:
+        onEnter:
+          command: houdini-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
+        onExit:
+          command: houdini-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame_range:
+          end: {{Task.Param.Frame}}
+          start: {{Task.Param.Frame}}
+          step: 1
+        ignore_input_nodes: true
+        render_node: /out/mantra1
+    actions:
+      onRun:
+        command: houdini-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      range: 1-2:1
+      type: INT
+- name: /out/mantra2-2
+  stepEnvironments:
+  - name: Houdini
+    description: Runs Houdini in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          ignore_input_nodes: true
+          render_node: /out/mantra2
+          scene_file: '{{Param.HipFile}}'
+          version: <HOUDINI_VERSION>
+          wedge_node: ''
+          wedgenum: ''
+      actions:
+        onEnter:
+          command: houdini-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
+        onExit:
+          command: houdini-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame_range:
+          end: {{Task.Param.Frame}}
+          start: {{Task.Param.Frame}}
+          step: 1
+        ignore_input_nodes: true
+        render_node: /out/mantra2
+    actions:
+      onRun:
+        command: houdini-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      range: 1-2:1
+      type: INT
+description: Render dependencies

--- a/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/render_dependencies_test/expected_job_bundle/template.yaml
@@ -147,4 +147,6 @@ steps:
     - name: Frame
       range: 1-2:1
       type: INT
+  dependencies:
+  - dependsOn: /out/mantra1-1
 description: Render dependencies


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have one last case to cover in integration tests, which is nodes with render dependencies!

### What was the solution? (How)
- Created a scene with two chained render nodes
- Added a test case for the submitter using this scene

### What is the impact of this change?
EVEN💥MORE🤯robust integration tests

### How was this change tested?
Unit tests to check for regressions. The new integ test case compares to results I got from manually testing this same case.

#### Please run the integration tests and paste the results below.
Windows:
```
================================================= test session starts =================================================
platform win32 -- Python 3.12.9, pytest-8.4.1, pluggy-1.6.0 -- C:\Users\miabatta\AppData\Local\hatch\env\virtual\deadline-cloud-for-houdini\rwEPARk8\integ\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\miabatta\GitHub\deadline-cloud-for-houdini
configfile: pyproject.toml
plugins: cov-6.2.1, xdist-3.8.0
1 worker [5 items]
scheduling tests via LoadScheduling

test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 20%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
[gw0] [ 40%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 60%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [ 80%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter

================================================= slowest 5 durations =================================================
55.16s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
52.16s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
8.73s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
8.35s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
8.31s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
============================================ 5 passed in 133.62s (0:02:13) ============================================
```

Linux:
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 20%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor 
[gw0] [ 40%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor 
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 60%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
[gw0] [ 80%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 

============================================ slowest 5 durations =============================================
24.80s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
23.58s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
3.53s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
3.38s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
3.32s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
============================================= 5 passed in 59.09s =============================================
```

### Was this change documented?
n/a
### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
