### PR TITLE
feat: Added Houdini 21.0.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -144,7 +144,7 @@ To run integration tests:
    ```powershell
    # Python version should be 3.9 for Houdini 19.5,
    # 3.10 for Houdini 20.0,
-   # and 3.11 for Houdini 20.5.
+   # and 3.11 for Houdini 20.5 & 21.0.
    pip install pywin32 --python-version=3.11 --only-binary=:all: --target="C:\\Program Files\\Side Effects Software\\Houdini 20.5.487\\python311\\lib\\site-packages"
    ```
 6. Run `hatch run integ:test`. **If you are on Windows**, you may need Admin privileges to run the tests.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ability to run Houdini efficiently on your render farm.
 
 This library requires:
 
-1. Houdini 19.5, 20.0, or 20.5
+1. Houdini 19.5, 20.0, 20.5 or 21.0
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 

--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -2,7 +2,7 @@
 <componentGroup>
     <name>deadline_cloud_for_houdini</name>
     <description>Deadline Cloud for Houdini</description>
-    <detailedDescription>Houdini plugin for submitting jobs to AWS Deadline Cloud. Compatible with Houdini 19.5-20.5</detailedDescription>
+    <detailedDescription>Houdini plugin for submitting jobs to AWS Deadline Cloud. Compatible with Houdini 19.5-21.0</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -311,6 +311,83 @@
                 </if>
             </postInstallationActionList>
         </component>
+         <component>
+            <name>houdini_21_0</name>
+            <description>Houdini 21.0</description>
+            <selected>0</selected>
+            <parameterList>
+                <directoryParameter>
+                    <name>houdini_21_0_packagedir</name>
+                    <description>Houdini 21.0 Packages Directory</description>
+                    <explanation>Enter the path to the Houdini 21.0 packages directory. For easiest installation, Houdini should be installed before installing Deadline Cloud for Houdini.</explanation>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>houdini-21-0-package-dir</cliOptionName>
+                    <cliOptionText>Path to the Houdini 21.0 packages directory. When the installer is run, if the HOUDINI_USER_PREF_DIR environment variable is set, this directory will default to the packages subdirectory at that path.</cliOptionText>
+                    <mustBeWritable>yes</mustBeWritable>
+                    <!-- Do not show this parameter on Windows; we will just add the installation directory to HOUDINI_PACKAGE_DIR. -->
+                    <ruleList>
+                        <platformTest type="windows" negate="true"/>
+                    </ruleList>
+                    <!-- For non-Windows, choose an appropriate default based on install scope and OS -->
+                    <preShowPageActionList>
+                        <!-- User (any): Set based on user pref -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_21_0_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <setInstallerVariable name="houdini_21_0_packagedir" value="${houdini_user_pref_dir_default}21.0/packages"/>
+                            </actionList>
+                        </if>
+
+                        <!-- System (any): Set based on default Houdini location for the OS -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_21_0_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="system"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="linux" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_21_0_packagedir" value="/opt/hfs21.0/packages" />
+                                    </actionList>
+                                </if>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_21_0_packagedir" value="/Applications/Houdini/Current/Frameworks/Houdini.framework/Versions/Current/Resources/packages"/>
+                                    </actionList>
+                                </if>
+                            </actionList>
+                        </if>
+                    </preShowPageActionList>
+                </directoryParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <!-- On Windows, we don't require copying the package file and can just set an environment variable.
+                For macOS and Linux, we must copy the file into the latest Houdini installation. -->
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="windows"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <fnAddPathEnvironmentVariable name="HOUDINI_PACKAGE_DIR" value="${houdini_packagedir}" scope="${installscope}"/>
+                    </actionList>
+                    <elseActionList>
+                        <fnCopyHoudiniPackageFile destinationDir="${houdini_21_0_packagedir}" />
+                    </elseActionList>
+                </if>
+            </postInstallationActionList>
+        </component>
     </componentList>
     <preInitializationActionList>
         <if>
@@ -325,6 +402,7 @@
                 <setInstallerVariable name="houdini_19_5_packagedir" value="${env(HOUDINI_USER_PREF_DIR)}/packages"/>
                 <setInstallerVariable name="houdini_20_0_packagedir" value="${env(HOUDINI_USER_PREF_DIR)}/packages"/>
                 <setInstallerVariable name="houdini_20_5_packagedir" value="${env(HOUDINI_USER_PREF_DIR)}/packages"/>
+                <setInstallerVariable name="houdini_21_0_packagedir" value="${env(HOUDINI_USER_PREF_DIR)}/packages"/>
             </actionList>
         </if>
         <if>
@@ -371,8 +449,8 @@
     </readyToInstallActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_houdini_summary" ask="0" cliOptionShow="0">
-            <value>Deadline Cloud for Houdini 19.5-20.5
-- Compatible with Houdini 19.5-20.5
+            <value>Deadline Cloud for Houdini 19.5-21.0
+- Compatible with Houdini 19.5-21.0
 - Install the integrated Houdini submitter files to the installation directory.
 - Copy the plug-in package file to the Houdini packages directory for each version.
 - Register the plug-in package file with Houdini by setting HOUDINI_PACKAGE_DIR on Windows.</value>

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -24,7 +24,7 @@ class HoudiniVersion:
 
     VERSION_REGEX = re.compile(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?")
 
-    PYTHON_VERSIONS = {"19.5": "3.9", "20.0": "3.10", "20.5": "3.11"}
+    PYTHON_VERSIONS = {"19.5": "3.9", "20.0": "3.10", "20.5": "3.11", "21.0": "3.11"}
 
     def __init__(self, arg_version: Optional[str] = None):
         version = self._get_houdini_version(arg_version)

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -67,13 +67,15 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         "--prefix",
         installation_path,
         "--enable-components",
-        "deadline_cloud_for_houdini,houdini_19_5,houdini_20_0,houdini_20_5",
-        "--houdini-20-5-package-dir",
+        "deadline_cloud_for_houdini,houdini_19_5,houdini_20_0,houdini_20_5,houdini_21_0",
+        "--houdini-19-5-package-dir",
         installation_path / "houdini19.5" / "packages",
         "--houdini-20-0-package-dir",
         installation_path / "houdini20.0" / "packages",
-        "--houdini-19-5-package-dir",
+        "--houdini-20-5-package-dir",
         installation_path / "houdini20.5" / "packages",
+        "--houdini-21-0-package-dir",
+        installation_path / "houdini21.0" / "packages",
     ]
     subprocess.run(args, check=True)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
[A new major version of Houdini is coming out!](https://www.sidefx.com/community/houdini-21-keynote/) Let's support it in the installer.

### What was the solution? (How)
- Added a new installer component
- Updated docs to include 21.0

### What is the impact of this change?
Users can install the Deadline Cloud submitter to use out-of-the-box with Houdini 21.0.

### How was this change tested?
- Unit tests
- Locally built the individual installer to manually verify it gets added to the right folders/env variables. Can't test that it works using Houdini 21.0 yet as it's still pre-release.

#### Please run the integration tests and paste the results below.
n/a; no changes to submitter/adaptor

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
Windows:
```
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
test/installer/test_installer.py::TestUserInstall::test_uninstall
test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
test/installer/test_installer.py::TestWindows::test_system_permissions
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
test/installer/test_installer.py::TestUserInstall::test_install
test/installer/test_installer.py::TestWindows::test_user_permissions
test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
[gw4] [  6%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestVerifySigning::test_macos_signing
[gw5] [ 13%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
[gw4] [ 20%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
[gw3] [ 26%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode
test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw3] [ 33%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing
[gw0] [ 40%] PASSED test/installer/test_installer.py::test_default_location
test/installer/test_installer.py::TestSystemInstall::test_install
[gw1] [ 46%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
test/installer/test_installer.py::TestSystemInstall::test_uninstall
[gw2] [ 53%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
test/installer/test_installer.py::TestVerifySigning::test_windows_signing
[gw2] [ 60%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing
[gw8] [ 66%] PASSED test/installer/test_installer.py::TestUserInstall::test_install
[gw6] [ 73%] PASSED test/installer/test_installer.py::TestWindows::test_user_permissions
[gw7] [ 80%] PASSED test/installer/test_installer.py::TestWindows::test_system_permissions
[gw0] [ 86%] PASSED test/installer/test_installer.py::TestSystemInstall::test_install
[gw9] [ 93%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall
[gw1] [100%] PASSED test/installer/test_installer.py::TestSystemInstall::test_uninstall

================================================= slowest 5 durations =================================================
253.34s setup    test/installer/test_installer.py::TestSystemInstall::test_install
253.14s setup    test/installer/test_installer.py::TestWindows::test_system_permissions
251.39s setup    test/installer/test_installer.py::TestUserInstall::test_install
250.96s setup    test/installer/test_installer.py::TestWindows::test_user_permissions
248.57s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
====================================== 9 passed, 6 skipped in 383.92s (0:06:23) =======================================
```

Linux:
```
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
[gw3] [  6%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw3] [ 13%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw0] [ 20%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
[gw3] [ 26%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw1] [ 33%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[system_installation] 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw1] [ 40%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw1] [ 46%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw1] [ 60%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 66%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw2] [ 73%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw0] [ 80%] PASSED test/installer/test_installer.py::test_tmp_directory_removed[user_installation] 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 86%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw3] [ 93%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw3] [100%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 

============================================================================================== slowest 5 durations ==============================================================================================
8.31s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
8.27s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
8.27s setup    test/installer/test_installer.py::TestUserInstall::test_install
8.25s call     test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
7.35s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
========================================================================================= 6 passed, 9 skipped in 17.04s =========================================================================================
```

### Was this change documented?
Yes in the repo's docstrings and instructions :)

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
