### PR TITLE
chore: pin the version of click that hatch uses to <8.3 due to Sentin…

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -118,7 +118,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "click<8.3"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 pip install --upgrade twine
 hatch -v run codebuild:lint
 hatch run codebuild:test

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 hatch run e2e:test

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 hatch run integ:test


### PR DESCRIPTION
related: aws-deadline/.github#56

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*