### PR TITLE
fix: unhelpful error message with multiple deadline cloud nodes in th…

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -5,6 +5,7 @@ import os
 import sys
 import yaml
 import json
+import traceback
 from typing import Any, Dict
 from pathlib import Path
 
@@ -159,6 +160,8 @@ def _get_rop_steps(rop: hou.Node):
     if err:
         raise Exception(f"hscript render: failed to list steps\n\n{str(err)}")
     rop_steps: list[dict[str, Any]] = []
+    deadline_node_seen = False
+
     for n in out.split("\n"):
         if not n.strip():
             continue
@@ -191,8 +194,13 @@ def _get_rop_steps(rop: hou.Node):
 
         node = hou.node(path)
 
-        # skip deadline and deadline_cloud rops
+        # we only want to skip the single root submission node
         if node.type().name() in ("deadline", "deadline_cloud"):
+            if deadline_node_seen:
+                raise RuntimeError(
+                    "The selected network contains multiple Deadline Cloud nodes. Only a single Deadline Cloud node should be used."
+                )
+            deadline_node_seen = True
             continue
 
         step_dict = {
@@ -477,12 +485,15 @@ def save_bundle_callback(kwargs):
             os.startfile(job_bundle_dir)
         hou.ui.displayMessage(
             f"Saved the submission as a job bundle: {job_bundle_dir}",
-            title="Houdini Job Submission",
+            title="Deadline Cloud Job Submission",
         )
     except Exception as exc:
         print("Error saving bundle")
         hou.ui.displayMessage(
-            str(exc), title="Houdini Job Submission", severity=hou.severityType.Warning
+            str(exc),
+            title="Deadline Cloud Job Submission",
+            severity=hou.severityType.Warning,
+            details=traceback.format_exc(),
         )
 
 
@@ -679,7 +690,10 @@ def submit_callback(kwargs):
         )
         print(str(exc))
         hou.ui.displayMessage(
-            str(exc), title="Houdini Job Submission", severity=hou.severityType.Warning
+            str(exc),
+            title="Deadline Cloud Job Submission",
+            severity=hou.severityType.Warning,
+            details=traceback.format_exc(),
         )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When there are multiple Deadline Cloud nodes in the rop network and a user presses submit or save bundle a warning dialog will display that simple shows a single digit such a "3".

### What was the solution? (How)
The unhelpful error message was coming from a Key Error when trying to determine the rop dependencies because we were skipping any deadline nodes and if there are multiple it was being skipped from one list, but not the actual dependency IDs.

I've added a check to raise an exception if we see more than a single Deadline Cloud node since we don't currently support having multiple Deadline Cloud nodes in the same graph.

### What is the impact of this change?
More helpful error messages for users

### How was this change tested?
Created a test scene with and without multiple Deadline Cloud nodes and ensured that with multiple nodes I was getting the new warning dialog and that without I was still able to submit the same as before.

- Have you run the unit tests?
Yes

#### Please run the integration tests and paste the results below.
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 16%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
[gw0] [ 50%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [ 83%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter

========================================================================================================================================================================== slowest 5 durations ===========================================================================================================================================================================
125.53s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
91.94s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
73.02s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
23.05s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
18.97s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
===================================================================================================================================================================== 6 passed in 350.73s (0:05:50) ======================================================================================================================================================================
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
