### PR TITLE
fix: aws credential error message on node creation is not actionable

### DIFF
--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/OnCreated
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/OnCreated
@@ -3,5 +3,5 @@ from botocore.exceptions import CredentialRetrievalError
 try:
     node = kwargs['node']
     node.hdaModule().update_queue_parameters_callback(kwargs)
-except CredentialRetrievalError:
-    print('AWS Deadline Cloud credentials are expired.')
+except CredentialRetrievalError as e:
+    print(e)

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -701,14 +701,30 @@ def settings_callback(kwargs):
     node = kwargs["node"]
     _show_farm_and_queue_as_refreshing(node)
     DeadlineConfigDialog.configure_settings(parent=hou.qt.mainWindow())
-    _apply_farm_and_queue_settings(node)
+    try:
+        _apply_farm_and_queue_settings(node)
+    except Exception as exc:
+        hou.ui.displayMessage(
+            str(exc),
+            title="Deadline Cloud",
+            severity=hou.severityType.Warning,
+            details=traceback.format_exc(),
+        )
 
 
 def login_callback(kwargs):
     node = kwargs["node"]
     _show_farm_and_queue_as_refreshing(node)
     DeadlineLoginDialog.login(parent=hou.qt.mainWindow())
-    _apply_farm_and_queue_settings(node)
+    try:
+        _apply_farm_and_queue_settings(node)
+    except Exception as exc:
+        hou.ui.displayMessage(
+            str(exc),
+            title="Deadline Cloud",
+            severity=hou.severityType.Warning,
+            details=traceback.format_exc(),
+        )
 
 
 def logout_callback(kwargs):


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/134

### What was the problem/requirement? (What/Why)

We had a custom error message that didn't tell users what to do when their credentials were expired.

### What was the solution? (How)

We now just pass the execption string which provides instructions for users to refresh their credentials.

At the same time, I've added a warning dialog for settings/login if the credentials aren't refreshed that prints the same information, but optionally includes the stack trace about the actual error

<img width="806" height="432" alt="image" src="https://github.com/user-attachments/assets/da3316df-6436-4e2e-9477-83067843e39f" />

### What is the impact of this change?

Customers have better instructions on how to fix their set-up

### How was this change tested?

Deployed it locally

#### Please run the integration tests and paste the results below.
N/A

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
