### PR TITLE
chore: add integration test workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,42 @@
+name: Houdini Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:  
+  MainlineLinuxIntegrationTest:
+    name: Linux Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: mainline
+      environment: mainline
+      os: linux
+  MainlineWindowsIntegrationTest:
+    name: Windows Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: mainline
+      environment: mainline
+      os: windows
+  MainlineMacOsIntegrationTest:
+    name: MacOS Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: mainline
+      environment: mainline
+      os: macos


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to add a workflow that can run the houdini integration tests

### What was the solution? (How)
Add a workflow that calls the reusable integ tests workflow to run houdini integration tests against mainline with a manual dispatch

### What is the impact of this change?
Can start houdini integration tests

### How was this change tested?
Same changes tested here: https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/18722117961

### Was this change documented?
n/a

### Is this a breaking change?
n.a

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*