### PR TITLE
docs: update broken links to Houdini Redshift and V-Ray samples

### DIFF
--- a/docs/user_guide/submitter/husk-rendering.md
+++ b/docs/user_guide/submitter/husk-rendering.md
@@ -28,7 +28,7 @@ Before using the Husk example job bundle, you will need:
 * A git clone of the [Deadline Cloud samples repository](https://github.com/aws-deadline/deadline-cloud-samples)
 
 * The Hydra render delegate available on the worker nodes
-    * Karma is included with Houdini. If you want to use other Hydra render delegates then you must provide them on the worker. See the deadline-cloud-samples repository for example Conda packages for[V-Ray](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/vray) and [Redshift](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/redshift) as one option to make them available on the worker nodes.
+    * Karma is included with Houdini. If you want to use other Hydra render delegates then you must provide them on the worker. See the deadline-cloud-samples repository for example Conda packages for[V-Ray](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/houdini-vray-7) and [Redshift](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/houdini-redshift-2026) as one option to make them available on the worker nodes.
 
 ### To Use the Husk Example Job Bundle
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Docs failed to deploy because of bad links in the recently added husk rendering page: https://github.com/aws-deadline/aws-deadline.github.io/actions/runs/19676835082/job/56360201160

### What was the solution? (How)
Fix the links

### What is the impact of this change?
Fixed doc deployment

### How was this change tested?

It wasn't other than the links are valid now. The link checking code must not run on local deployments of the docs which is how this was missed.

### Was this change documented?

Is a docs change

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
