### PR TITLE
chore(docs): add missing newline for list formatting to husk docs page

### DIFF
--- a/docs/user_guide/submitter/husk-rendering.md
+++ b/docs/user_guide/submitter/husk-rendering.md
@@ -11,6 +11,7 @@ This means you cannot use the submitter node to create a single job that will ex
 AWS Deadline Cloud provides an [**example Husk job bundle**](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles/houdini_husk_usd_render) that enables USD export rendering workflows outside of the Houdini submitter. You will need to export the USD scene yourself separately from Houdini before using the example job bundle. 
 
 The Husk example job bundle:
+
 - Allows direct submission of USD scenes for rendering via Husk and a chosen Hydra render delegate without launching Houdini and consuming a Houdini engine license during the render
 - Automatically introspects USD files to find any file dependencies within to attach using job attachments
 - Provides a simple GUI for configuration of common Husk settings and submission


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
One of the lists was missing formatting because of a missing newline before starting the list items

### What was the solution? (How)
Add the newline :(

### What is the impact of this change?
Formatting fixed

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
