### PR TITLE
feat(log): add path mapping logging for $JOB and $POSE env variables

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -137,9 +137,11 @@ To run integration tests:
 3. Set the environment variable `HYTHON_EXECUTABLE` to the location of `hython` in your Houdini installation. For example:
    * On Linux: `export HYTHON_EXECUTABLE='/opt/hfs20.5.487/bin/hython'`
    * On Windows (powershell): `$Env:HYTHON_EXECUTABLE='C:\Program Files\Side Effects Software\Houdini 20.5.487\bin\hython.exe'`
+   * On Mac: `export HYTHON_EXECUTABLE="/Applications/Houdini/Houdini20.5.487/Frameworks/Houdini.framework/Resources/bin/hython"`
 4. Set the environment variable `HOUDINI_VERSION` to the version of Houdini you want to test against. For example:
    * On Linux: `export HOUDINI_VERSION='20.5.487'`
    * On Windows (powershell): `$Env:HOUDINI_VERSION='20.5.487'`
+   * On Mac: `export HOUDINI_VERSION='20.5.487'`
 5. **On Windows**: Install `pywin32` into Houdini's Python site packages using Admin privileges.
    ```powershell
    # Python version should be 3.9 for Houdini 19.5,

--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -58,6 +58,10 @@ class HoudiniHandler:
             if not err and mapped_path:
                 hou.putenv(env, mapped_path.strip())
                 print(f"Set {env} to {mapped_path.strip()}")
+            elif err:
+                print(f"Error mapping {env}: {err}")
+            elif not mapped_path:
+                print(f"Could not map {env}, no rules in HOUDINI_PATHMAP applied")
 
         # Reload the env variables
         hou.hscript("varchange")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

While troubleshooting an asset pathmapping issue I was having, I added a couple of lines to the output to make it clear when pathmapping rules are or are not being applied. 

### What was the solution? (How)

In _path_map_envs I've added logging if there's an error after path-mapping, or if one of the paths we've mapped doesn't get changed. There isn't a guarantee that these failures are worth failing the job for, but they would help in troubleshooting.

### What is the impact of this change?

```
ADAPTOR_OUTPUT: STDOUT: Mapping POSE (C:/Users/artist/Documents/houdini20.5/poselib)
```

becomes

```
ADAPTOR_OUTPUT: STDOUT: Mapping POSE (C:/Users/artist/Documents/houdini20.5/poselib)
ADAPTOR_OUTPUT: STDOUT: Could not map POSE, no rules in HOUDINI_PATHMAP applied
```

### How was this change tested?

By setting the scene file's $POSE or $JOB variables to paths not covered by HOUDINI_PATHMAP and confirming that the error messages were shown.

#### Please run the integration tests and paste the results below.

============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0 -- /Users/jusbla/Library/Application Support/hatch/env/virtual/deadline-cloud-for-houdini/I_FD3ieF/integ/bin/python
cachedir: .pytest_cache
rootdir: /Users/jusbla/Code/deadline-cloud-for-houdini
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0
created: 1/1 worker
1 worker [6 items]

scheduling tests via LoadScheduling

test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 16%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor 
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor 
[gw0] [ 50%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor 
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
[gw0] [ 83%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 

============================= slowest 5 durations ==============================
117.69s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
85.11s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
67.15s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
14.95s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
14.65s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
======================== 6 passed in 314.49s (0:05:14) =========================


#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

### Was this change documented?

No documentation changes needed for this change. I did add some Mac examples of environment variables to make running integration tests easier.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
