### PR TITLE
ci: add integration tests to merges and release process

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,41 +2,49 @@ name: Houdini Integration Tests
 
 on:
   workflow_dispatch:
-
+    inputs:
+      ref_type:
+        description: 'Reference type to test'
+        required: true
+        default: 'branch'
+        type: choice
+        options:
+          - branch
+          - tag
+      branch:
+        description: 'Branch to test (e.g., mainline, feature-branch)'
+        required: false
+        default: 'mainline'
+        type: string
+      tag:
+        description: 'Tag to test (only used when ref_type is "tag")'
+        required: false
+        type: string
+  push:
+    branches:
+      - 'mainline'
+      
+      
 jobs:  
-  MainlineLinuxIntegrationTest:
-    name: Linux Integration Tests
+  IntegrationTests:
+    name: ${{ matrix.name }} Integration Tests
     permissions:
       id-token: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            name: Linux
+          - os: windows
+            name: Windows
+          - os: macos
+            name: MacOS
     uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
-      os: linux
-  MainlineWindowsIntegrationTest:
-    name: Windows Integration Tests
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
-      os: windows
-  MainlineMacOsIntegrationTest:
-    name: MacOS Integration Tests
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
-      os: macos
+      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
+      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
+      os: ${{ matrix.os }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -29,13 +29,36 @@ jobs:
 
   UnitTests:
     needs: [TagRelease]
-    name: Unit and Integration Tests
+    name: Unit Tests
     uses: ./.github/workflows/code_quality.yml
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
+  IntegrationTests:
+    needs: [TagRelease, UnitTests]
+    name: ${{ matrix.name}} Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            name: Linux
+          - os: windows
+            name: Windows
+          - os: macos
+            name: MacOS
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      os: ${{ matrix.os }}
+
   PreRelease:
-      needs: [TagRelease, UnitTests]
+      needs: [TagRelease, UnitTests, IntegrationTests]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
       permissions:
         id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integration tests were not running as part of the release process for the Blender DCC adaptor. This meant releases could be published without validating that the integration tests pass on all supported platforms (Linux, Windows, macOS).

We also want integration tests to run when we merge to mainline

### What was the solution? (How)
Added three integration test jobs to the release_publish.yml workflow:

* LinuxIntegrationTest
* WindowsIntegrationTest
* MacOsIntegrationTest

These jobs run in parallel after the release is tagged and use the reusable integration test workflow from aws-deadline/.github. The PreRelease job now depends on all integration tests passing before proceeding with the release.

Set `integration_tests.yml` to run on push to mainline and added options for running on different branches or tags

### What is the impact of this change?
* Releases will now be blocked if integration tests fail on any platform, ensuring higher quality releases and catching platform-specific issues before they reach production.

### How was this change tested?
This change modifies the CI/CD workflow itself. Testing will occur when the next release is triggered, at which point the integration tests will run automatically as part of the release process.

**Please run the integration tests and paste the results below.**
N/A - This change adds integration tests to the release workflow. The tests will run automatically on the next release.

**If installer/ was modified or a file was added/removed from src/, then update the installer tests and post the test results below.**
N/A - No changes to installer or src files.

### Was this change documented?
N/A - This is a CI/CD workflow change that doesn't affect user-facing functionality or APIs.

### Is this a breaking change?
No.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
