### PR TITLE
chore: Add PythonPanel using deadline-cloud library

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,24 +132,25 @@ Integration tests are located in the `test/unit` directory. Individual test case
 To run integration tests:
 1. Log out of any Deadline Cloud Monitor profiles with `deadline auth logout`.
    * Running the integration tests while logged in may result to queue parameters being written to the test job template, which will fail the tests.
-2. Configure your Houdini licensing.
-3. Install the dev submitter for the major and minor version of Houdini you want to test against: `hatch run install --houdini-version <MAJOR>.<MINOR>`
-3. Set the environment variable `HYTHON_EXECUTABLE` to the location of `hython` in your Houdini installation. For example:
+1. Configure your Houdini licensing.
+1. Run `git lfs pull` to retrieve the expected test images.
+1. Install the dev submitter for the major and minor version of Houdini you want to test against: `hatch run install --houdini-version <MAJOR>.<MINOR>`
+1. Set the environment variable `HYTHON_EXECUTABLE` to the location of `hython` in your Houdini installation. For example:
    * On Linux: `export HYTHON_EXECUTABLE='/opt/hfs20.5.487/bin/hython'`
    * On Windows (powershell): `$Env:HYTHON_EXECUTABLE='C:\Program Files\Side Effects Software\Houdini 20.5.487\bin\hython.exe'`
    * On Mac: `export HYTHON_EXECUTABLE="/Applications/Houdini/Houdini20.5.487/Frameworks/Houdini.framework/Resources/bin/hython"`
-4. Set the environment variable `HOUDINI_VERSION` to the version of Houdini you want to test against. For example:
+1. Set the environment variable `HOUDINI_VERSION` to the version of Houdini you want to test against. For example:
    * On Linux: `export HOUDINI_VERSION='20.5.487'`
    * On Windows (powershell): `$Env:HOUDINI_VERSION='20.5.487'`
    * On Mac: `export HOUDINI_VERSION='20.5.487'`
-5. **On Windows**: Install dependencies into Houdini's Python site packages using Admin privileges.
+1. **On Windows**: Install dependencies into Houdini's Python site packages using Admin privileges.
    ```powershell
    # Python version should be 3.9 for Houdini 19.5,
    # 3.10 for Houdini 20.0,
    # and 3.11 for Houdini 20.5 & 21.0.
    pip install -r requirements-integ-dcc-env.txt --python-version=3.11 --only-binary=:all: --target="C:\\Program Files\\Side Effects Software\\Houdini 20.5.487\\python311\\lib\\site-packages"
    ```
-6. Run `hatch run integ:test`. **If you are on Windows**, you may need Admin privileges to run the tests.
+1. Run `hatch run integ:test`. **If you are on Windows**, you may need Admin privileges to run the tests.
    * To only run submitter tests, run `hatch run integ:test_submitters`. This runs tests with the `@pytest.mark.submitter` decorator.
    * To only run adaptor tests, run `hatch run integ:test_adaptors`. This runs tests with the `@pytest.mark.adaptor` decorator.
 

--- a/python_panels/deadline_cloud.pypanel
+++ b/python_panels/deadline_cloud.pypanel
@@ -1,0 +1,18 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<?xml version="1.0" encoding="UTF-8"?>
+<pythonPanelDocument>
+  <!-- This file contains definitions of Python interfaces and the
+ interfaces menu.  It should not be hand-edited when it is being
+ used by the application.  Note, that two definitions of the
+ same interface or of the interfaces menu are not allowed
+ in a single file. -->
+  <interface name="deadline_cloud" label="Deadline Cloud" icon="MISC_python" showNetworkNavigationBar="false" help_url="">
+    <script><![CDATA[
+
+# Inject script here
+
+]]></script>
+    <includeInToolbarMenu menu_position="201" create_separator="false"/>
+    <help><![CDATA[]]></help>
+  </interface>
+</pythonPanelDocument>

--- a/src/deadline/houdini_submitter/panel/submitter_panel.py
+++ b/src/deadline/houdini_submitter/panel/submitter_panel.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from qtpy.QtWidgets import (
+    QComboBox,
+    QLabel,
+    QLineEdit,
+    QWidget,
+    QGridLayout,
+    QVBoxLayout,
+)
+from deadline.client.job_bundle.submission import AssetReferences
+from deadline_cloud_for_houdini._assets import _get_scene_asset_references
+from deadline_cloud_for_houdini.hip_settings import HoudiniSubmitterUISettings
+from deadline_cloud_for_houdini.houdini_submitter_widget import SceneSettingsWidget, create_dialog
+from deadline_cloud_for_houdini.submitter import submit_callback
+
+
+class SubmitterPanel(QWidget):
+    def __init__(self, parent, deadline_cloud_widget):
+        super().__init__(parent=parent)
+        self.deadline_cloud_widget = deadline_cloud_widget
+
+        self._build_ui()
+
+    def _build_ui(self):
+        parent_layout = QVBoxLayout(self)
+        frame_info_layout = QGridLayout(self)
+
+        qt_pos_index = 0
+        frame_info_layout.addWidget(QLabel("Valid Frame Range"), qt_pos_index, 0)
+        frame_info_layout.addWidget(QComboBox(self), qt_pos_index, 1)
+
+        qt_pos_index += 1
+        frame_info_layout.addWidget(QLabel("Start/End/Inc"), qt_pos_index, 0)
+        frame_info_layout.addWidget(QLineEdit(self), qt_pos_index, 1)
+        frame_info_layout.addWidget(QLineEdit(self), qt_pos_index, 2)
+        frame_info_layout.addWidget(QLineEdit(self), qt_pos_index, 3)
+
+        qt_pos_index += 1
+        frame_info_layout.addWidget(QLabel("Render with Take"), qt_pos_index, 0)
+        frame_info_layout.addWidget(QComboBox(self), qt_pos_index, 1)
+
+        parent_layout.addLayout(frame_info_layout)
+        parent_layout.addWidget(self.deadline_cloud_widget)
+
+
+def onCreateInterface():
+
+    # Convention for how Houdini references nodes in its Python panels; we can't include **kwargs in the function signature.
+    # Ignore this as to not set off the linter.
+    n = kwargs["paneTab"].currentNode()  # type: ignore # noqa:F821
+
+    widget = create_dialog(
+        job_setup_widget_type=SceneSettingsWidget,
+        initial_job_settings=HoudiniSubmitterUISettings(),
+        initial_shared_parameter_values={},
+        auto_detected_attachments=_get_scene_asset_references(n),
+        attachments=AssetReferences(),
+        on_create_job_bundle_callback=submit_callback,
+        submitter_name="Houdini Submitter",
+        show_host_requirements_tab=True,
+    )
+
+    panel = SubmitterPanel(parent=None, deadline_cloud_widget=widget)
+
+    return panel

--- a/src/deadline/houdini_submitter/panel/submitter_panel.py
+++ b/src/deadline/houdini_submitter/panel/submitter_panel.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import hou
+
 from qtpy.QtWidgets import (
     QComboBox,
     QLabel,
@@ -8,10 +10,14 @@ from qtpy.QtWidgets import (
     QGridLayout,
     QVBoxLayout,
 )
+from qtpy.QtCore import Qt  # type: ignore
 from deadline.client.job_bundle.submission import AssetReferences
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
+from deadline.client.dataclasses import SubmitterInfo
+from deadline_cloud_for_houdini._version import version as houdini_submitter_version
 from deadline_cloud_for_houdini._assets import _get_scene_asset_references
 from deadline_cloud_for_houdini.hip_settings import HoudiniSubmitterUISettings
-from deadline_cloud_for_houdini.houdini_submitter_widget import SceneSettingsWidget, create_dialog
+from deadline_cloud_for_houdini.houdini_submitter_widget import SceneSettingsWidget
 from deadline_cloud_for_houdini.submitter import submit_callback
 
 
@@ -26,19 +32,19 @@ class SubmitterPanel(QWidget):
         parent_layout = QVBoxLayout(self)
         frame_info_layout = QGridLayout(self)
 
-        qt_pos_index = 0
-        frame_info_layout.addWidget(QLabel("Valid Frame Range"), qt_pos_index, 0)
-        frame_info_layout.addWidget(QComboBox(self), qt_pos_index, 1)
+        grid_row = 0
+        frame_info_layout.addWidget(QLabel("Valid Frame Range"), grid_row, 0)
+        frame_info_layout.addWidget(QComboBox(self), grid_row, 1)
 
-        qt_pos_index += 1
-        frame_info_layout.addWidget(QLabel("Start/End/Inc"), qt_pos_index, 0)
-        frame_info_layout.addWidget(QLineEdit(self), qt_pos_index, 1)
-        frame_info_layout.addWidget(QLineEdit(self), qt_pos_index, 2)
-        frame_info_layout.addWidget(QLineEdit(self), qt_pos_index, 3)
+        grid_row += 1
+        frame_info_layout.addWidget(QLabel("Start/End/Inc"), grid_row, 0)
+        frame_info_layout.addWidget(QLineEdit(self), grid_row, 1)
+        frame_info_layout.addWidget(QLineEdit(self), grid_row, 2)
+        frame_info_layout.addWidget(QLineEdit(self), grid_row, 3)
 
-        qt_pos_index += 1
-        frame_info_layout.addWidget(QLabel("Render with Take"), qt_pos_index, 0)
-        frame_info_layout.addWidget(QComboBox(self), qt_pos_index, 1)
+        grid_row += 1
+        frame_info_layout.addWidget(QLabel("Render with Take"), grid_row, 0)
+        frame_info_layout.addWidget(QComboBox(self), grid_row, 1)
 
         parent_layout.addLayout(frame_info_layout)
         parent_layout.addWidget(self.deadline_cloud_widget)
@@ -47,17 +53,27 @@ class SubmitterPanel(QWidget):
 def onCreateInterface():
 
     # Convention for how Houdini references nodes in its Python panels; we can't include **kwargs in the function signature.
+    # See https://www.sidefx.com/docs/houdini/ref/windows/pythonpaneleditor.html#interfaces-tab for more information.
     # Ignore this as to not set off the linter.
     n = kwargs["paneTab"].currentNode()  # type: ignore # noqa:F821
 
-    widget = create_dialog(
+    widget = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=HoudiniSubmitterUISettings(),
         initial_shared_parameter_values={},
         auto_detected_attachments=_get_scene_asset_references(n),
         attachments=AssetReferences(),
         on_create_job_bundle_callback=submit_callback,
-        submitter_name="Houdini Submitter",
+        # submitter_into replaces submitter_name as of deadline-cloud 0.54.0: https://github.com/aws-deadline/deadline-cloud/releases/tag/0.54.0
+        # Until we upgrade versions, this code will throw a linting error. Ignore for now since this code is still unreachable without setup.
+        submitter_info=SubmitterInfo(  # type: ignore
+            submitter_name="Houdini",
+            submitter_package_name="deadline-cloud-for-houdini",
+            submitter_package_version=houdini_submitter_version,
+            host_application_name="Houdini",
+            host_application_version=hou.applicationVersionString(),
+        ),
+        f=Qt.Tool,
         show_host_requirements_tab=True,
     )
 

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/constants.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/constants.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from enum import Enum
+
+
+class FrameRange(Enum):
+    RENDER_CURRENT_FRAME = 0
+    RENDER_FRAME_RANGE = 1
+    RENDER_FRAME_RANGE_ONLY_STRICT = 2
+
+
+_NONE_SELECTED_TEXT = "<none selected>"
+_REFRESHING_TEXT = "<refreshing>"
+
+
+class RenderStrategy(Enum):
+    SEQUENTIAL = "SEQUENTIAL"
+    PARALLEL = "PARALLEL"

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/hip_settings.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/hip_settings.py
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .constants import FrameRange, RenderStrategy
+
+
+@dataclass
+class HoudiniSubmitterUISettings:
+    """Settings that the submitter UI will use."""
+
+    name: str = field(default="Houdini Submission", metadata={"sticky": True})
+    description: str = field(default="", metadata={"sticky": True})
+
+    # Frame range parameters.
+    # These parameter names are copied over from the Houdini interface.
+    trange: int = field(default=FrameRange.RENDER_CURRENT_FRAME.value, metadata={"sticky": True})
+    f1: int = field(default=1, metadata={"sticky": True})
+    f2: int = field(default=1, metadata={"sticky": True})
+    f3: int = field(default=1, metadata={"sticky": True})
+
+    hip_file: str = field(default="", metadata={"sticky": True})
+    render_strategy: str = field(default=RenderStrategy.SEQUENTIAL.value, metadata={"sticky": True})
+    separate_steps: bool = field(default=False, metadata={"sticky": True})
+    auto_unlock_rops: bool = field(default=False, metadata={"sticky": True})
+    auto_parse_hip: bool = field(default=True, metadata={"sticky": True})
+    auto_save_hip: bool = field(default=True, metadata={"sticky": True})
+
+    include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
+    adaptor_wheels_dir: Optional[str] = field(default=None, metadata={"sticky": True})

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/houdini_submitter_widget.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/houdini_submitter_widget.py
@@ -36,7 +36,7 @@ class SceneSettingsWidget(QWidget):
 
         qt_pos_index += 1
         self.adaptor_wheels_directory_picker = DirectoryPickerWidget(
-            initial_directory=hou.getEnvConfigValue("HIP"),
+            initial_directory=hou.getenv("HIP"),
             directory_label="Adaptor Wheels",
             parent=self,
         )

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/houdini_submitter_widget.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/houdini_submitter_widget.py
@@ -1,0 +1,114 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import hou
+
+from qtpy.QtCore import Qt  # type: ignore
+from qtpy.QtWidgets import QCheckBox, QWidget, QGridLayout
+
+from .hip_settings import HoudiniSubmitterUISettings
+
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
+from deadline.client.ui.widgets.path_widgets import DirectoryPickerWidget
+
+
+class SceneSettingsWidget(QWidget):
+    def __init__(self, initial_settings: HoudiniSubmitterUISettings, parent=None):
+        super().__init__(parent=parent)
+
+        self.dev_options = os.environ.get("DEADLINE_ENABLE_DEVELOPER_OPTIONS", "").upper() == "TRUE"
+
+        self._build_ui()
+        self._load(initial_settings)
+
+    def _build_ui(self) -> None:
+        """Set up the UI."""
+        layout = QGridLayout(self)
+
+        qt_pos_index = 0
+
+        self.separate_step_check = QCheckBox("Submit Dependencies as Separate Steps", self)
+        layout.addWidget(self.separate_step_check, qt_pos_index, 0)
+
+        qt_pos_index += 1
+        self.include_adaptor_wheels_check = QCheckBox("Include Adaptor Wheels", self)
+        layout.addWidget(self.include_adaptor_wheels_check, qt_pos_index, 0)
+
+        qt_pos_index += 1
+        self.adaptor_wheels_directory_picker = DirectoryPickerWidget(
+            initial_directory=hou.getEnvConfigValue("HIP"),
+            directory_label="Adaptor Wheels",
+            parent=self,
+        )
+
+        layout.addWidget(self.adaptor_wheels_directory_picker, qt_pos_index, 0)
+
+        self.include_adaptor_wheels_check.stateChanged.connect(self._include_adaptor_wheels_changed)
+
+        qt_pos_index += 1
+        self.auto_unlock_rops_check = QCheckBox("Automatically unlock ROPs", self)
+        layout.addWidget(self.auto_unlock_rops_check, qt_pos_index, 0)
+
+        qt_pos_index += 1
+        self.auto_parse_hip_check = QCheckBox("Automatically parse scene (.hip) references", self)
+        layout.addWidget(self.auto_parse_hip_check, qt_pos_index, 0)
+
+        qt_pos_index += 1
+        self.auto_save_hip_check = QCheckBox("Automatically save scene (.hip) file", self)
+        layout.addWidget(self.auto_save_hip_check, qt_pos_index, 0)
+
+    def _load(self, settings: HoudiniSubmitterUISettings) -> None:
+        """
+        Populates the UI elements with the contents of `settings`.
+
+        Args:
+            settings: The Houdini-specific job settings to populate the UI with
+        """
+
+        self.separate_step_check.setChecked(settings.separate_steps)
+        self.include_adaptor_wheels_check.setChecked(settings.include_adaptor_wheels)
+        self.adaptor_wheels_directory_picker.setEnabled(settings.include_adaptor_wheels)
+
+    def _include_adaptor_wheels_changed(self, state):
+        self.adaptor_wheels_directory_picker.setEnabled(Qt.CheckState(state) == Qt.Checked)
+
+    def update_settings(self, settings: HoudiniSubmitterUISettings) -> None:
+        """
+        Updates the Houdini submitter settings according to values set in the job settings panel.
+
+        Args:
+            settings: A dataclass with Houdini-specific job settings to update
+        """
+
+        settings.separate_steps = self.separate_step_check.isChecked()
+        settings.include_adaptor_wheels = self.include_adaptor_wheels_check.isChecked()
+        if settings.include_adaptor_wheels:
+            settings.adaptor_wheels_dir = self.adaptor_wheels_directory_picker.getText()
+        settings.auto_unlock_rops = self.auto_unlock_rops_check.isChecked()
+        settings.auto_parse_hip = self.auto_parse_hip_check.isChecked()
+        self.auto_save_hip_check = self.auto_save_hip_check.isChecked()
+
+
+def create_dialog(
+    job_setup_widget_type,
+    initial_job_settings,
+    initial_shared_parameter_values,
+    auto_detected_attachments,
+    attachments,
+    on_create_job_bundle_callback,
+    submitter_name,
+    show_host_requirements_tab,
+) -> SubmitJobToDeadlineDialog:
+
+    dialog = SubmitJobToDeadlineDialog(
+        job_setup_widget_type=job_setup_widget_type,
+        initial_job_settings=initial_job_settings,
+        initial_shared_parameter_values=initial_shared_parameter_values,
+        auto_detected_attachments=auto_detected_attachments,
+        attachments=attachments,
+        on_create_job_bundle_callback=on_create_job_bundle_callback,
+        submitter_name=submitter_name,
+        f=Qt.Tool,
+        show_host_requirements_tab=show_host_requirements_tab,
+    )
+    return dialog

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/houdini_submitter_widget.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/houdini_submitter_widget.py
@@ -8,7 +8,6 @@ from qtpy.QtWidgets import QCheckBox, QWidget, QGridLayout
 
 from .hip_settings import HoudiniSubmitterUISettings
 
-from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
 from deadline.client.ui.widgets.path_widgets import DirectoryPickerWidget
 
 
@@ -86,29 +85,4 @@ class SceneSettingsWidget(QWidget):
             settings.adaptor_wheels_dir = self.adaptor_wheels_directory_picker.getText()
         settings.auto_unlock_rops = self.auto_unlock_rops_check.isChecked()
         settings.auto_parse_hip = self.auto_parse_hip_check.isChecked()
-        self.auto_save_hip_check = self.auto_save_hip_check.isChecked()
-
-
-def create_dialog(
-    job_setup_widget_type,
-    initial_job_settings,
-    initial_shared_parameter_values,
-    auto_detected_attachments,
-    attachments,
-    on_create_job_bundle_callback,
-    submitter_name,
-    show_host_requirements_tab,
-) -> SubmitJobToDeadlineDialog:
-
-    dialog = SubmitJobToDeadlineDialog(
-        job_setup_widget_type=job_setup_widget_type,
-        initial_job_settings=initial_job_settings,
-        initial_shared_parameter_values=initial_shared_parameter_values,
-        auto_detected_attachments=auto_detected_attachments,
-        attachments=attachments,
-        on_create_job_bundle_callback=on_create_job_bundle_callback,
-        submitter_name=submitter_name,
-        f=Qt.Tool,
-        show_host_requirements_tab=show_host_requirements_tab,
-    )
-    return dialog
+        settings.auto_save_hip = self.auto_save_hip_check.isChecked()

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -166,7 +166,7 @@ def test_default_location(installer_path: Path):
     # Since windows doesn't have text mode, it'll pop-up a gui. We use the timeout to ensure it stops
     try:
         help_result = subprocess.run(
-            [installer_path, *text_mode, "--help"], capture_output=True, text=True, timeout=5
+            [installer_path, *text_mode, "--help"], capture_output=True, text=True, timeout=7
         )
         assert (
             help_result.returncode == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are porting the Houdini submitter to use the `deadline-cloud` UI library so it can access new features as soon as they are released. This is a multi-step process.

First we need to create a Python panel to use for the Deadline Cloud node.

<img width="482" height="588" alt="Screenshot 2026-01-07 at 10 56 14" src="https://github.com/user-attachments/assets/924c8fb9-a85c-45e4-9136-e211dcb01d1c" />

### What was the solution? (How)
- Created scaffolding for the new panel
- Added a submitter settings dataclass & settings widget to use with the `deadline-cloud` library functions
- Sidebar, bumped a timeout in the installer tests because it failed on my machine. Didn't happen a second time, but I figured I'd commit a cheeky bump just in case others encounter this

### What is the impact of this change?
**Nothing yet!**

This preps switching the UI over without actually hooking anything up. To try out these changes locally:

1. In `pyproject.toml`, change the `deadline` dependency to use `>= 0.49,< 0.54`
2. In `scripts/install_dev_submitter.py`, add an `--upgrade` argument to the list in `_build_deps_env`
3. Run `hatch run install --houdini-version X.Y`
4. Open Houdini and go to **Windows**, **Python Panel Editor**
5. Choose **New Interface**
  - For **Save To**, replace `default.pypanel` with `deadline_cloud.pypanel`
  - Check **Show in Parameters Pane**, and for **For Operators**, enter `Driver/deadline_cloud`
  - Copy and paste the contents of `panel/submitter_panel.py` into the **Script** tab

<img width="792" height="820" alt="Screenshot 2026-01-07 at 10 56 31" src="https://github.com/user-attachments/assets/ef0563eb-2924-4a33-a17b-c9aaea09a0ed" />

6. Choose **Accept**
7. Restart Houdini
8. Add a Deadline Cloud node to view the new panel

### How was this change tested?
`hatch run all:test` passed

#### Please run the integration tests and paste the results below.
macOS/Houdini 20.0.896:
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 16%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
[gw0] [ 50%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [ 83%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter

======================================= slowest 5 durations =======================================
117.47s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
88.52s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
67.27s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
14.86s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
14.84s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
================================== 6 passed in 317.83s (0:05:17) ==================================
```

macOS/Houdini 20.5.787:
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 16%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
[gw0] [ 50%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [ 83%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter

======================================= slowest 5 durations =======================================
120.93s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
88.34s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
80.62s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
15.14s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
15.12s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
================================== 6 passed in 335.12s (0:05:35) ==================================
```

macOS/Houdini 21.0.440:
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 16%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
[gw0] [ 50%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [ 83%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter

======================================= slowest 5 durations =======================================
147.31s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
90.56s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
74.19s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
16.13s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
15.96s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
================================== 6 passed in 360.42s (0:06:00) ==================================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
macOS:
```
===================== slowest 5 durations =====================
15.26s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
15.22s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
14.98s call     test/installer/test_installer.py::test_tmp_directory_removed[user_installation]
14.61s call     test/installer/test_installer.py::test_tmp_directory_removed[system_installation]
13.68s setup    test/installer/test_installer.py::TestUserInstall::test_install
========== 6 passed, 9 skipped, 1 warning in 19.90s ===========
```

### Was this change documented?
Not yet; will be documented on feature completion.

### Is this a breaking change?
_not yet_

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
