### PR TITLE
fix: detection of locked HDAs didn't follow fetch nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pycache__/
 .tox
 /htmlcov
 **/otls/backup
-plugin_env
+plugin_env*
 
 # Hatch version temp file
 *_version.py

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -272,6 +272,32 @@ def _get_parameter_values(node: hou.Node) -> dict[str, Any]:
     return {"parameterValues": parameter_values}
 
 
+def _follow_fetch_nodes(node: hou.Node) -> hou.Node:
+    """Follow a chain of fetch nodes to find the final target node.
+
+    Args:
+        node: The starting node, which may or may not be a fetch node
+
+    Returns:
+        The final non-fetch node in the chain
+    """
+    current_node = node
+    visited_nodes = set()  # Prevent infinite loops
+
+    while (
+        current_node
+        and current_node.type().nameWithCategory() == "Driver/fetch"
+        and current_node.path() not in visited_nodes
+    ):
+        visited_nodes.add(current_node.path())
+        inner_node = current_node.node(current_node.parm("source").eval())
+        if not inner_node:
+            break
+        current_node = inner_node
+
+    return current_node
+
+
 def _is_node_locked(rop_path: str) -> bool:
     """Check rop path lineage for any locked nodes.
 
@@ -518,6 +544,10 @@ def submit_callback(kwargs):
     # check for locked rops, Karma for example
     locked_rops = []
     for n in all_inputs:
+
+        # Check for and follow any fetch nodes
+        n = _follow_fetch_nodes(n)
+
         node_path = n.path()
         if _is_node_locked(node_path):
             locked_rops.append(node_path)

--- a/test/unit/deadline_submitter_for_houdini/test_submit_callback.py
+++ b/test/unit/deadline_submitter_for_houdini/test_submit_callback.py
@@ -8,6 +8,7 @@ from .mock_hou import hou_module as hou
 
 from deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter import (
     submit_callback,
+    _follow_fetch_nodes,
 )
 
 
@@ -79,3 +80,77 @@ def test_error_message_for_missing_queue_id(empty_queue_id, default_adc_node, mo
         severity=hou.severityType.Warning,
     )
     mock_api.get_boto3_client.assert_not_called()
+
+
+class TestUnlockingROPs:
+    """Tests for ROP unlocking functionality including fetch node following"""
+
+    def test_chained_fetch_nodes_to_target(self):
+        """Test: fetch1 -> fetch2 -> fetch3 -> target"""
+        # Create fetch chain: fetch1 -> fetch2 -> fetch3 -> target
+        fetch1 = mock.MagicMock()
+        fetch1.type.return_value.nameWithCategory.return_value = "Driver/fetch"
+        fetch1.path.return_value = "/out/fetch1"
+        fetch1.parm.return_value.eval.return_value = "fetch2"
+
+        fetch2 = mock.MagicMock()
+        fetch2.type.return_value.nameWithCategory.return_value = "Driver/fetch"
+        fetch2.path.return_value = "/out/fetch2"
+        fetch2.parm.return_value.eval.return_value = "fetch3"
+
+        fetch3 = mock.MagicMock()
+        fetch3.type.return_value.nameWithCategory.return_value = "Driver/fetch"
+        fetch3.path.return_value = "/out/fetch3"
+        fetch3.parm.return_value.eval.return_value = "geometry1"
+
+        target_node = mock.MagicMock()
+        target_node.type.return_value.nameWithCategory.return_value = "Driver/geometry"
+        target_node.path.return_value = "/out/geometry1"
+
+        # Set up chain
+        fetch1.node.return_value = fetch2
+        fetch2.node.return_value = fetch3
+        fetch3.node.return_value = target_node
+
+        # Test fetch following
+        result = _follow_fetch_nodes(fetch1)
+        assert result is target_node
+
+    def test_infinite_recursion_prevention(self):
+        """Test: fetch1 -> fetch2 -> fetch1 (circular reference)"""
+        fetch1 = mock.MagicMock()
+        fetch1.type.return_value.nameWithCategory.return_value = "Driver/fetch"
+        fetch1.path.return_value = "/out/fetch1"
+        fetch1.parm.return_value.eval.return_value = "fetch2"
+
+        fetch2 = mock.MagicMock()
+        fetch2.type.return_value.nameWithCategory.return_value = "Driver/fetch"
+        fetch2.path.return_value = "/out/fetch2"
+        fetch2.parm.return_value.eval.return_value = "fetch1"
+
+        # Set up circular reference
+        fetch1.node.return_value = fetch2
+        fetch2.node.return_value = fetch1
+
+        result = _follow_fetch_nodes(fetch1)
+        assert result is fetch1
+
+    def test_non_fetch_node_passthrough(self):
+        """Test: geometry node (not a fetch) should return itself"""
+        geometry_node = mock.MagicMock()
+        geometry_node.type.return_value.nameWithCategory.return_value = "Driver/geometry"
+        geometry_node.path.return_value = "/out/geometry1"
+
+        result = _follow_fetch_nodes(geometry_node)
+        assert result is geometry_node
+
+    def test_fetch_node_with_invalid_source(self):
+        """Test: fetch node with empty/invalid source should return itself"""
+        fetch_node = mock.MagicMock()
+        fetch_node.type.return_value.nameWithCategory.return_value = "Driver/fetch"
+        fetch_node.path.return_value = "/out/fetch1"
+        fetch_node.parm.return_value.eval.return_value = "nonexistent"
+        fetch_node.node.return_value = None  # Source doesn't exist
+
+        result = _follow_fetch_nodes(fetch_node)
+        assert result is fetch_node


### PR DESCRIPTION
Fixes: #254 

### What was the problem/requirement? (What/Why)
The submitter has logic to detect and unlock Houdini [HDAs](https://www.sidefx.com/docs/houdini/assets/intro.html) that are locked and may need to be unlocked for rendering to succeed because parameters within them need to be modified on the render workers. This existing logic wouldn't follow fetch nodes which is a common practice in Houdini.
### What was the solution? (How)
Added a new check to follow any fetch nodes, including chains of them(which I see no reason why anyone would do...but you can). The last non fetch node found in the chain is then checked to see if it's a locked HDA.

### What is the impact of this change?
Better detection of HDAs that need to be unlocked.

### How was this change tested?
* Added some simple new unit tests for the fetch node detection
* Created a scene file following the reproduction steps in #254 and verified that with this change the pop-up appears stating that there are locked HDAs in the scene and asking to unlock them. The submission then succeeded on my farm.
* Created additional test cases in Houdini manually with an infinite loop of fetch nodes and verified it was detected and didn't crash as well as a test case for multiple fetch nodes in a row.

#### Please run the integration tests and paste the results below.
```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 16%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
[gw0] [ 50%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [ 66%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
[gw0] [ 83%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter

========================================================================================================================================================================== slowest 5 durations ==========================================================================================================================================================================
165.29s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
115.12s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
93.97s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
21.16s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter
21.12s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter
===================================================================================================================================================================== 6 passed in 437.53s (0:07:17) =====================================================================================================================================================================
```

### Was this change documented?

Only in the original bug report which will be linked to this PR.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
