### PR TITLE
test: Added Adaptor integration tests to validate opening and closing of Houdini.

### DIFF
--- a/test/integ/test_houdini_adaptors.py
+++ b/test/integ/test_houdini_adaptors.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 from .helpers.test_runners import run_command, run_houdini_adaptor_test
 from .helpers.image_comparison import assert_all_images_close
+import os
+import psutil
+
+from deadline.houdini_adaptor.HoudiniAdaptor import HoudiniAdaptor
 
 
 @pytest.mark.adaptor
@@ -91,3 +95,150 @@ class TestAdaptors:
         assert_all_images_close(
             script_location / "render_dependencies_test" / "expected_images", tmp_path
         )
+
+    def test_adaptor_open_close(
+        self, hython_location: Path, script_location: Path, tmp_path: Path
+    ) -> None:
+        """Test that the adaptor can successfully open and close the Houdini client."""
+        run_command(
+            [
+                str(hython_location),
+                str(script_location / "minimal_test" / "_test_hip.py"),
+                "--",
+                str(script_location),
+                str(tmp_path),
+                "adaptor",
+            ]
+        )
+
+        adaptor = HoudiniAdaptor(
+            {
+                "scene_file": f"{str(tmp_path)}/test.hip",
+                "render_node": "/out/mantra1",
+                "version": os.environ["HOUDINI_VERSION"],
+            }
+        )
+
+        adaptor.on_start()
+        assert adaptor._houdini_is_running
+
+        # Validate process is actually running using PID
+        assert adaptor._houdini_client
+        pid = adaptor._houdini_client.pid
+        assert psutil.pid_exists(pid)
+
+        adaptor.on_cleanup()
+        assert not adaptor._houdini_is_running
+        assert not psutil.pid_exists(pid)
+
+    def test_adaptor_cancel_closes_houdini(
+        self, hython_location: Path, script_location: Path, tmp_path: Path
+    ) -> None:
+        """Test that on_cancel closes the Houdini client."""
+        run_command(
+            [
+                str(hython_location),
+                str(script_location / "minimal_test" / "_test_hip.py"),
+                "--",
+                str(script_location),
+                str(tmp_path),
+                "adaptor",
+            ]
+        )
+
+        adaptor = HoudiniAdaptor(
+            {
+                "scene_file": f"{str(tmp_path)}/test.hip",
+                "render_node": "/out/mantra1",
+                "version": os.environ["HOUDINI_VERSION"],
+            }
+        )
+
+        adaptor.on_start()
+        assert adaptor._houdini_is_running
+
+        assert adaptor._houdini_client
+        pid = adaptor._houdini_client.pid
+        assert psutil.pid_exists(pid)
+
+        adaptor.on_cancel()
+        assert not adaptor._houdini_is_running
+        assert not psutil.pid_exists(pid)
+
+    def test_adaptor_daemon_open_close(
+        self, hython_location: Path, script_location: Path, tmp_path: Path
+    ) -> None:
+        """Test that the adaptor can open and close the Houdini client in daemon mode."""
+        import tempfile
+        import subprocess
+        import json
+        import time
+
+        run_command(
+            [
+                str(hython_location),
+                str(script_location / "minimal_test" / "_test_hip.py"),
+                "--",
+                str(script_location),
+                str(tmp_path),
+                "adaptor",
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            connection_file = Path(tmpdir) / "connection.json"
+
+            # Start daemon backend
+            init_data = {
+                "scene_file": f"{str(tmp_path)}/test.hip",
+                "render_node": "/out/mantra1",
+                "version": os.environ["HOUDINI_VERSION"],
+            }
+
+            try:
+                start_process = subprocess.run(
+                    [
+                        "houdini-openjd",
+                        "daemon",
+                        "start",
+                        "--connection-file",
+                        str(connection_file),
+                        "--init-data",
+                        json.dumps(init_data),
+                    ]
+                )
+
+                assert start_process.returncode == 0
+
+                # Wait for connection file
+                timeout = time.time() + 10
+                while not connection_file.exists() and time.time() < timeout:
+                    time.sleep(0.1)
+                assert connection_file.exists()
+
+                # Connect and verify process is running
+                connection_data = json.loads(connection_file.read_text())
+                assert "socket" in connection_data, "Connection file should contain socket"
+
+            finally:
+                # Stop daemon
+                if connection_file.exists():
+                    stop_cmd = [
+                        "houdini-openjd",
+                        "daemon",
+                        "stop",
+                        "--connection-file",
+                        str(connection_file),
+                    ]
+
+                    stop_process = subprocess.run(
+                        stop_cmd,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+
+                    # Verify daemon stopped successfully
+                    assert (
+                        stop_process.returncode == 0
+                    ), f"Daemon stop failed: {stop_process.stderr}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is no integration test for checking that the adaptor can start and stop Houdini. The minimal render tests partially cover this by starting Houdini but we never check that the adaptor closes Houdini when complete. 

### What was the solution? (How)

Added a few tests to check starting Houdini and closing it. Cancel should close Houdini and the same behaviour should be scene when running as a daemon. 

### What is the impact of this change?

More confidence in the Adaptors control over the Houdini process.

### How was this change tested?
Ran tests:

#### Please run the integration tests and paste the results below.

```
bash-5.2$ hatch run integ:test
================================================================================================================ test session starts =================================================================================================================
platform darwin -- Python 3.10.8, pytest-8.4.2, pluggy-1.6.0 -- /Users/erico/Library/Application Support/hatch/env/virtual/deadline-cloud-for-houdini/RJSCNW7O/integ/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/forks/deadline-cloud-for-houdini
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0
1 worker [9 items]     
scheduling tests via LoadScheduling

test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 11%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor 
[gw0] [ 22%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor 
[gw0] [ 33%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_open_close 
[gw0] [ 44%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_open_close 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_cancel_closes_houdini 
[gw0] [ 55%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_cancel_closes_houdini 
test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_daemon_open_close 
[gw0] [ 66%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_daemon_open_close 
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [ 77%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
[gw0] [ 88%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 
[gw0] [100%] PASSED test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 

================================================================================================================ slowest 5 durations =================================================================================================================
140.66s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor
94.70s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor
81.38s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
37.52s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_daemon_open_close
32.49s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_open_close
=========================================================================================================== 9 passed in 479.34s (0:07:59) ============================================================================================================
```


### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
