### PR TITLE
fix: handle AccessDeniedException when user lacks GetFarm permission

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
@@ -203,8 +203,8 @@ def _get_control_for_int_parameter(param: JobParameter) -> hou.ParmTemplate:  # 
         else param["name"]
     )
     default = _get_default_value(param)
-    min = (int(param["minValue"]),) if "minValue" in param else (0,)
-    max = (int(param["maxValue"]),) if "maxValue" in param else (10,)
+    min = int(param["minValue"]) if "minValue" in param else 0
+    max = int(param["maxValue"]) if "maxValue" in param else 10
     min_is_strict = "minValue" in param
     max_is_strict = "maxValue" in param
     hidden = _is_param_hidden(param)

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -9,6 +9,8 @@ import traceback
 from typing import Any, Dict
 from pathlib import Path
 
+from botocore.exceptions import ClientError
+
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client import api
 from deadline.client.job_bundle.submission import AssetReferences
@@ -782,8 +784,14 @@ def _apply_farm_and_queue_settings(node):
         node.parm("queue").set(_NONE_SELECTED_TEXT)
         return
     deadline = api.get_boto3_client("deadline")
-    farm_response = deadline.get_farm(farmId=farm_id)
-    node.parm("farm").set(farm_response["displayName"])
+    try:
+        farm_response = deadline.get_farm(farmId=farm_id)
+        node.parm("farm").set(farm_response["displayName"])
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "AccessDeniedException":
+            node.parm("farm").set(farm_id)
+        else:
+            raise
     queue_id = get_setting("defaults.queue_id")
     if not queue_id:
         node.parm("queue").set(_NONE_SELECTED_TEXT)

--- a/test/unit/deadline_submitter_for_houdini/test_apply_farm_and_queue_settings.py
+++ b/test/unit/deadline_submitter_for_houdini/test_apply_farm_and_queue_settings.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+from .mock_hou import hou_module as hou
+
+from deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter import (
+    _apply_farm_and_queue_settings,
+    _NONE_SELECTED_TEXT,
+)
+
+
+class TestApplyFarmAndQueueSettings:
+    def test_access_denied_falls_back_to_farm_id(self, mock_api):
+        """When user lacks GetFarm permission, display farm ID instead of name."""
+        farm_id = "farm-1234567890"
+        node = hou.node()
+
+        mock_api.get_boto3_client.return_value.get_farm.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access Denied"}},
+            "GetFarm",
+        )
+
+        with mock.patch(
+            "deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter.get_setting",
+            side_effect=lambda key: farm_id if key == "defaults.farm_id" else None,
+        ):
+            _apply_farm_and_queue_settings(node)
+
+        # Check that farm was set to farm_id (not display name) and queue to none selected
+        node.parm.assert_has_calls(
+            [
+                mock.call("farm"),
+                mock.call().set(farm_id),
+                mock.call("queue"),
+                mock.call().set(_NONE_SELECTED_TEXT),
+            ]
+        )


### PR DESCRIPTION
When a user only has queue permissions but not farm permissions, the submitter would fail when trying to get the farm display name. Now it gracefully falls back to displaying the farm ID instead.

Also fixes Houdini 21 compatibility issue where IntParmTemplate min/max parameters must be plain integers, not tuples.

Fixes: https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/336

### What was the problem/requirement? (What/Why)
A poor UX and error messages for users with queue only permissions

- Have you run the unit tests?
Yes

#### Please run the integration tests and paste the results below.
I'll need help here as i cannot run the integration tests as i've set things up.

### Was this change documented? N/A

### Is this a breaking change? No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
