### PR TITLE
chore: lock virtualenv<21 for quick release to pypi fix

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -141,7 +141,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi


### PR DESCRIPTION
Needed to publish to pypi, should look into removing the py3.9 usage

ref: https://github.com/aws-deadline/deadline-cloud-for-maya/pull/370

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
