### PR TITLE
fix: Normalize paths in test_usd_scene_dependency_detection

### DIFF
--- a/test/integ/test_houdini_submitters.py
+++ b/test/integ/test_houdini_submitters.py
@@ -313,15 +313,17 @@ class TestSubmitters:
         with open(job_history_dir / "asset_references.yaml") as f:
             actual_refs = yaml.safe_load(f)
 
-        actual_input_files: set[str] = set(actual_refs["assetReferences"]["inputs"]["filenames"])
+        actual_input_files: set[str] = {
+            os.path.normcase(f) for f in actual_refs["assetReferences"]["inputs"]["filenames"]
+        }
 
         # All USD layers and assets must be detected
         expected_files = {
-            str(usd_dir / "scene.usda"),
-            str(usd_dir / "lighting.usda"),
-            str(usd_dir / "model.usda"),
-            str(usd_dir / "heavy_asset.usda"),
-            str(usd_dir / "textures" / "wood.exr"),
+            os.path.normcase(str(usd_dir / "scene.usda")),
+            os.path.normcase(str(usd_dir / "lighting.usda")),
+            os.path.normcase(str(usd_dir / "model.usda")),
+            os.path.normcase(str(usd_dir / "heavy_asset.usda")),
+            os.path.normcase(str(usd_dir / "textures" / "wood.exr")),
         }
 
         for expected in expected_files:
@@ -330,11 +332,13 @@ class TestSubmitters:
             ), f"Missing USD dependency: {expected}\nActual files: {actual_input_files}"
 
         # Hip file must also be present
-        assert scene_location_posix in actual_input_files
+        assert os.path.normcase(scene_location_posix) in actual_input_files
 
         # Output directory from RenderProduct must be detected (resolved from relative path)
-        actual_output_dirs: list[str] = actual_refs["assetReferences"]["outputs"]["directories"]
-        expected_output_dir: str = str(usd_dir / "renders")
+        actual_output_dirs: set[str] = {
+            os.path.normcase(d) for d in actual_refs["assetReferences"]["outputs"]["directories"]
+        }
+        expected_output_dir: str = os.path.normcase(str(usd_dir / "renders"))
         assert (
             expected_output_dir in actual_output_dirs
         ), f"Missing output directory: {expected_output_dir}\nActual dirs: {actual_output_dirs}"


### PR DESCRIPTION
What was the problem/requirement? (What/Why)

   Follow-up to #343. The Windows integration test test_usd_scene_dependency_detection was failing due to drive letter casing differences in path comparisons. On Windows, UsdUtils.ComputeAllDependencies and os.path.normpath can return paths with a lowercase drive letter (e.g., c:\...) while tmp_path uses uppercase (C:\...). The test assertions compared these as strings, causing false failures.

   What was the solution? (How)

   Used os.path.normcase() on both expected and actual paths in the integration test assertions. This normalizes casing and separators on Windows and is a no-op on Linux/macOS.

   What is the impact of this change?

   The integration test now passes on Windows. No production code changes.

   How was this change tested?
   - Integration test test_usd_scene_dependency_detection passes on macOS and Linux. Windows validation pending CI run.

   ### Submitter integ test
```
2026/04/15 16:50:41-07:00 test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
2026/04/15 16:50:41-07:00 [gw0][36m [ 25%] [0m[32mPASSED[0m test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter 
2026/04/15 16:50:47-07:00 test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
2026/04/15 16:50:47-07:00 [gw0][36m [ 50%] [0m[32mPASSED[0m test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter 
2026/04/15 16:50:52-07:00 test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 
2026/04/15 16:50:52-07:00 [gw0][36m [ 75%] [0m[32mPASSED[0m test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter 
2026/04/15 16:50:58-07:00 test/integ/test_houdini_submitters.py::TestSubmitters::test_usd_scene_dependency_detection 
2026/04/15 16:50:58-07:00 [gw0][36m [100%] [0m[32mPASSED[0m test/integ/test_houdini_submitters.py::TestSubmitters::test_usd_scene_dependency_detection 
2026/04/15 16:50:58-07:00  2026/04/15 16:50:58-07:00 ============================= slowest 5 durations ==============================2026/04/15 16:50:58-07:00 6.01s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter2026/04/15 16:50:58-07:00 5.80s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter2026/04/15 16:50:58-07:00 5.73s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter2026/04/15 16:50:58-07:00 5.64s call     test/integ/test_houdini_submitters.py::TestSubmitters::test_usd_scene_dependency_detection2026/04/15 16:50:58-07:00 0.00s setup    test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter2026/04/15 16:50:58-07:00 
[32m============================== [32m[1m4 passed[0m[32m in 25.60s[0m[32m ==============================[0m2026/04/15 16:50:59-07:00 Process pid 4710 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Adaptor integ tests
```
2026/04/15 16:48:40-07:00 test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor <- ../../../Users/ruizjair/workplace/jairaws/deadline-cloud-for-houdini/test/integ/test_houdini_adaptors.py 
2026/04/15 16:48:40-07:00 [gw0][36m [ 33%] [0m[32mPASSED[0m test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor <- ../../../Users/ruizjair/workplace/jairaws/deadline-cloud-for-houdini/test/integ/test_houdini_adaptors.py 
2026/04/15 16:49:12-07:00 test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor <- ../../../Users/ruizjair/workplace/jairaws/deadline-cloud-for-houdini/test/integ/test_houdini_adaptors.py 
2026/04/15 16:49:12-07:00 [gw0][36m [ 66%] [0m[32mPASSED[0m test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor <- ../../../Users/ruizjair/workplace/jairaws/deadline-cloud-for-houdini/test/integ/test_houdini_adaptors.py 
2026/04/15 16:50:06-07:00 test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor <- ../../../Users/ruizjair/workplace/jairaws/deadline-cloud-for-houdini/test/integ/test_houdini_adaptors.py 
2026/04/15 16:50:07-07:00 [gw0][36m [100%] [0m[32mPASSED[0m test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor <- ../../../Users/ruizjair/workplace/jairaws/deadline-cloud-for-houdini/test/integ/test_houdini_adaptors.py 
2026/04/15 16:50:07-07:00  2026/04/15 16:50:07-07:00 ============================= slowest 5 durations ==============================2026/04/15 16:50:07-07:00 54.70s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor2026/04/15 16:50:07-07:00 32.04s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor2026/04/15 16:50:07-07:00 29.22s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor2026/04/15 16:50:07-07:00 0.00s setup    test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor2026/04/15 16:50:07-07:00 0.00s setup    test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor2026/04/15 16:50:07-07:00 
[32m======================== [32m[1m3 passed[0m[32m in 117.31s (0:01:57)[0m[32m =========================[0m2026/04/15 16:50:07-07:00 Process pid 4558 exited with code: 0 (unsigned) / 0x0 (hex)
```

   If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

   N/A — no changes to installer/ or file additions/removals in src/.

   Was this change documented?

   No documentation changes needed. This is a test-only fix.

   Is this a breaking change?

   No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
