### PR TITLE
chore: process improvements

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -3,6 +3,9 @@ name: Code Quality
 on:
   pull_request:
     branches: [ mainline, release, 'patch_*' ]
+  push:
+    # Run on mainline pushes to populate the Actions cache that PRs restore from.
+    branches: [ mainline ]
   workflow_call:
     inputs:
       branch:

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -21,6 +21,7 @@ jobs:
     name: Version Bump
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     secrets: inherit

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -57,6 +57,13 @@ jobs:
       tag: ${{ needs.TagRelease.outputs.tag }}
       os: ${{ matrix.os }}
 
+  ManualTestGate:
+    needs: [TagRelease, BuildInstaller]
+    runs-on: ubuntu-latest
+    environment: release-gate
+    steps:
+      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
+
   PreRelease:
       needs: [TagRelease, UnitTests, IntegrationTests]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
@@ -93,14 +100,14 @@ jobs:
   IsCondaReady:
     needs: Publish
     runs-on: ubuntu-latest
-    environment: release
+    environment: release-gate
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
     steps:
       - run: |
          :
 
   ReleaseInstaller:
-    needs: [TagRelease, IsCondaReady]
+    needs: [TagRelease, IsCondaReady, ManualTestGate]
     uses: aws-deadline/.github/.github/workflows/reusable_release_installers.yml@mainline
     secrets: inherit
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release process is a bit tedious.

### What was the solution? (How)
- Improve pip and hatch caching with CI actions. (Caching was added in shared workflows already.)
- Add permissions to release note process so they can be LLM generated
- Add a single manual approval step instead of requiring manual approvals on every release step. Before merging, will require a new ManualReleaseGate environment and removing approvals for the release environment

### What is the impact of this change?
Faster releases

### How was this change tested?
Works in deadline-cloud repo

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
