### PR TITLE
feat: Notify customers if newer submitter is available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.49,< 0.51",
+    "deadline >= 0.55.1,< 0.56",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/OnCreated
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/OnCreated
@@ -2,6 +2,7 @@ from botocore.exceptions import CredentialRetrievalError
 
 try:
     node = kwargs['node']
+    node.hdaModule().check_and_show_update_dialog()
     node.hdaModule().update_queue_parameters_callback(kwargs)
 except CredentialRetrievalError as e:
     print(e)

--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/PythonModule
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/PythonModule
@@ -1,1 +1,2 @@
 from deadline_cloud_for_houdini.submitter import callback, update_queue_parameters_callback
+from deadline_cloud_for_houdini.update_utils import check_and_show_update_dialog

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/update_utils.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/update_utils.py
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for checking and displaying update notifications."""
+
+import logging
+from dataclasses import dataclass
+
+from deadline.client.api import safe_check_for_updates, UpdateCheckResult, UpdateCheckStatus
+from deadline.client.ui.dialogs.update_available_dialog import UpdateAvailableDialog
+
+from ._version import version_tuple as adaptor_version_tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SessionState:
+    """Session-level state: once the user dismisses the update dialog,
+    don't show it again until Houdini is restarted."""
+
+    update_dismissed: bool = False
+
+
+_session_state = _SessionState()
+
+
+def _check_for_update() -> UpdateCheckResult:
+    """Check if a newer version of the Houdini submitter is available.
+
+    Returns:
+        An UpdateCheckResult describing whether an update is available.
+    """
+    current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
+    return safe_check_for_updates(
+        integration_name="deadline-cloud-for-houdini",
+        current_version=current_version,
+    )
+
+
+def check_and_show_update_dialog() -> bool:
+    """Check for updates and show the update dialog if one is available.
+
+    If the user previously dismissed the dialog in this Houdini session,
+    the check is skipped entirely.
+
+    Returns:
+        True if the user clicked Download (caller should skip opening the submitter),
+        False otherwise.
+    """
+    if _session_state.update_dismissed:
+        return False
+
+    update_result = _check_for_update()
+    if update_result.status != UpdateCheckStatus.SUCCESS:
+        return False
+
+    if not update_result.update_available:
+        return False
+
+    update_dialog = UpdateAvailableDialog(
+        integration_name="Houdini",
+        current_version=update_result.current_version or "",
+        latest_version=update_result.latest_version or "",
+        download_url=update_result.download_url or "",
+        release_notes_url="https://github.com/aws-deadline/deadline-cloud-for-houdini/releases",
+    )
+    update_dialog.exec_()
+    if update_dialog.user_downloaded:
+        return True
+    # User dismissed — suppress for the rest of this Houdini session
+    _session_state.update_dismissed = True
+    return False

--- a/test/unit/deadline_submitter_for_houdini/__init__.py
+++ b/test/unit/deadline_submitter_for_houdini/__init__.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 # we must mock UI code
 mock_modules = [
+    "deadline.client.ui.deadline_authentication_status",
     "PySide2",
     "PySide2.QtCore",
     "PySide2.QtGui",

--- a/test/unit/deadline_submitter_for_houdini/test_update_utils.py
+++ b/test/unit/deadline_submitter_for_houdini/test_update_utils.py
@@ -1,0 +1,193 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from deadline.client.api import UpdateCheckResult, UpdateCheckStatus
+
+from deadline.houdini_submitter.python.deadline_cloud_for_houdini.update_utils import (
+    _check_for_update,
+    _session_state,
+    check_and_show_update_dialog,
+)
+
+MODULE = "deadline.houdini_submitter.python.deadline_cloud_for_houdini.update_utils"
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    """Reset session state before each test."""
+    _session_state.update_dismissed = False
+
+
+class TestCheckForUpdate:
+    """Tests for _check_for_update()."""
+
+    @patch(f"{MODULE}.safe_check_for_updates")
+    def test_passes_correct_integration_name(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.1.0",
+        )
+
+        # WHEN
+        _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["integration_name"] == "deadline-cloud-for-houdini"
+
+    @patch(f"{MODULE}.safe_check_for_updates")
+    def test_formats_version_from_tuple(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="1.2.3",
+        )
+
+        # WHEN
+        with patch(f"{MODULE}.adaptor_version_tuple", (1, 2, 3, "final", 0)):
+            _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["current_version"] == "1.2.3"
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for check_and_show_update_dialog()."""
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_false_when_no_update(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.1.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_false_on_error_status(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.NETWORK_ERROR,
+            current_version="0.1.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_true_when_user_downloads(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.1.0",
+            update_available=True,
+            latest_version="0.2.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is True
+        mock_dialog.exec_.assert_called_once()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_dismiss_sets_session_state(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.1.0",
+            update_available=True,
+            latest_version="0.2.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        assert _session_state.update_dismissed is True
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_skips_check_when_previously_dismissed(self, mock_check):
+        # GIVEN
+        _session_state.update_dismissed = True
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        mock_check.assert_not_called()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_download_does_not_set_dismissed(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.1.0",
+            update_available=True,
+            latest_version="0.2.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        check_and_show_update_dialog()
+
+        # THEN
+        assert _session_state.update_dismissed is False
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_dialog_receives_correct_release_notes_url(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.1.0",
+            update_available=True,
+            latest_version="0.2.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        check_and_show_update_dialog()
+
+        # THEN
+        call_kwargs = mock_dialog_cls.call_args[1]
+        assert (
+            call_kwargs["release_notes_url"]
+            == "https://github.com/aws-deadline/deadline-cloud-for-houdini/releases"
+        )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Customers did not know whether they were on the latest submitter or not. This means they would not have the latest bug fixes or features to work with our product. 

This is based off a similar PR for Cinema 4D: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/414

### What was the solution? (How)

This adds a dialog which checks our download manifests and if there's a new update available notifies customer  that. 

Currently testing. 


### What is the impact of this change?

### How was this change tested?

Here's the test cases that I manually tested in Houdini 21 on Mac:

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open Houdini → AWS Deadline Cloud → Submit to Deadline Cloud | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "Houdini", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | Houdini GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |
| 17 | Click "Don't remind me again" | Will dismiss and also never show the dialog again | No crash | YES |
| 18 | Click "Dismiss" | Does not show the dialog again for the session| No crash | YES | 

### Was this change documented?

This change does not require documentation. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*