### PR TITLE
docs: Add kiro powers to setup, design, develop

### DIFF
--- a/.kiro/powers/houdini-design-power/POWER.md
+++ b/.kiro/powers/houdini-design-power/POWER.md
@@ -1,0 +1,73 @@
+---
+name: houdini-design-power
+version: 1.0.0
+displayName: Houdini Design Power
+description: Structured design assistant for deadline-cloud-for-houdini - create design documents, research Houdini APIs, and plan features
+keywords:
+  - houdini
+  - deadline
+  - design
+  - architecture
+  - documentation
+  - research
+  - submitter
+  - adaptor
+  - hda
+author: AWS Deadline Cloud Team
+---
+
+# Houdini Design Power
+
+Structured design assistant for the deadline-cloud-for-houdini project. Helps create design documents, research Houdini APIs, and plan features for the submitter plugin and OpenJD adaptor.
+
+## What This Power Does
+
+- Creates structured design documents following a consistent 4-section format
+- Provides architecture context for the submitter, adaptor, and HDA
+- Guides research into Houdini Python APIs and SideFX documentation
+- Links to external references (GitHub repos, SideFX docs, AWS docs)
+
+## When to Use This Power
+
+Use this power when you need to:
+- Design a new feature for the submitter or adaptor
+- Write a design document for a code change
+- Research Houdini APIs before implementation
+- Understand the existing architecture before modifying it
+- Plan changes to the HDA parameter interface
+
+## Quick Start
+
+1. **Start a design:** "Create a design document for [feature description]"
+2. **Research an API:** "How does Houdini's [API] work? Show me code examples."
+3. **Understand architecture:** "Explain how the submitter generates job templates"
+4. **Plan a change:** "I need to add [parameter] to the submitter. What files need to change?"
+
+## Design Document Sections
+
+Every design document follows this structure:
+
+1. **Problem Statement** — What problem are we solving? Who is affected?
+2. **Proposed Solution** — How do we solve it? What changes are needed?
+3. **Implementation Plan** — Step-by-step plan with file changes and test strategy
+4. **Alternatives Considered** — What other approaches were evaluated and why were they rejected?
+
+## Architecture Context
+
+### Submitter
+- Houdini plugin loaded via package system (JSON)
+- ROP node defined as an HDA with DialogScript and PythonModule
+- Core logic in `submitter.py`, `_assets.py`, `queue_parameters.py`
+- Generates OpenJD job templates from ROP node parameters
+
+### Adaptor
+- pip-installable package with `houdini-openjd` CLI
+- Implements OpenJD lifecycle: `on_start`, `on_run`, `on_stop`, `on_cleanup`
+- Launches hython and communicates via socket (HoudiniClient)
+- JSON schemas define `init_data` and `run_data` contracts
+
+### HDA
+- Located at `otls/deadline_cloud.hda/Driver_1deadline__cloud/`
+- DialogScript defines the parameter interface
+- PythonModule contains callback functions
+- Edited via Houdini's Asset Manager UI

--- a/.kiro/powers/houdini-design-power/steering/deadline-cloud-architecture.md
+++ b/.kiro/powers/houdini-design-power/steering/deadline-cloud-architecture.md
@@ -1,0 +1,116 @@
+# Deadline Cloud Architecture for Houdini
+
+## System Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    User's Workstation                    │
+│                                                         │
+│  ┌─────────┐    ┌──────────────────┐    ┌───────────┐  │
+│  │ Houdini │───▶│ Submitter Plugin │───▶│ Deadline   │  │
+│  │  (GUI)  │    │  (ROP Node/HDA)  │    │ Cloud API  │  │
+│  └─────────┘    └──────────────────┘    └─────┬─────┘  │
+│                                               │         │
+└───────────────────────────────────────────────┼─────────┘
+                                                │
+                                    ┌───────────▼──────────┐
+                                    │   AWS Deadline Cloud  │
+                                    │   (Job Scheduling)    │
+                                    └───────────┬──────────┘
+                                                │
+┌───────────────────────────────────────────────┼─────────┐
+│                   Render Farm                  │         │
+│                                               │         │
+│  ┌──────────────┐    ┌─────────────────────┐  │         │
+│  │   Adaptor     │───▶│     hython          │  │         │
+│  │ (houdini-openjd)   │  (HoudiniClient)    │  │         │
+│  └──────────────┘    └─────────────────────┘  │         │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### 1. Submitter Plugin (Workstation)
+
+**What it does:** Provides a Deadline Cloud ROP node in Houdini. Users connect it to a render node, configure job settings, and submit or save a job bundle.
+
+**How it loads:** Via Houdini's package system. A JSON file at `~/houdini{X.Y}/packages/` sets `PYTHONPATH` and `hpath` to point at the plugin source.
+
+**Key flow:**
+1. User creates a Deadline Cloud ROP node in `/out` network
+2. Connects a render node (Mantra, Karma, etc.) to the Deadline Cloud node
+3. Configures job name, frame range, queue, and other settings
+4. Clicks "Submit" or "Save Bundle"
+5. Submitter generates an OpenJD job template and uploads assets
+
+### 2. Adaptor (Render Farm)
+
+**What it does:** Runs on render farm workers. Receives job data from Deadline Cloud, launches hython, loads the HIP file, and executes renders.
+
+**How it runs:** As the `houdini-openjd` CLI command, invoked by the Deadline Cloud worker agent.
+
+**Key flow:**
+1. Worker agent calls `houdini-openjd` with init_data (HIP file, render node)
+2. `on_start`: Launches hython, loads HIP file, configures render settings
+3. `on_run`: Renders a specific frame (called once per task/frame)
+4. `on_stop`: Cleans up after the render batch
+5. `on_cleanup`: Terminates hython process
+
+### 3. HoudiniClient (Inside hython)
+
+**What it does:** Runs inside the hython process. Receives commands from the adaptor via a socket connection and executes them using the `hou` API.
+
+**Key flow:**
+1. Adaptor starts hython with the HoudiniClient script
+2. Client connects to the adaptor's socket server
+3. Adaptor sends commands (load scene, set parameters, render)
+4. Client executes commands and returns results
+
+## Data Flow
+
+### Submission
+```
+ROP Node Parameters → submitter.py → OpenJD Job Template → Deadline Cloud API
+                      _assets.py   → Job Attachments (files to upload)
+```
+
+### Rendering
+```
+Deadline Cloud → Worker Agent → houdini-openjd (adaptor)
+                                    ↓
+                              adaptor.py (on_start)
+                                    ↓
+                              hython + HoudiniClient
+                                    ↓
+                              houdini_handler.py (execute render)
+                                    ↓
+                              Render output files
+```
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `deadline` | Deadline Cloud client library, job attachments, GUI |
+| `openjd-adaptor-runtime` | OpenJD adaptor lifecycle, socket communication |
+
+Version constraints are defined in `pyproject.toml` under `[project] dependencies`.
+
+## Supported Houdini Versions
+
+| Houdini | Python | Status |
+|---------|--------|--------|
+| 19.5 | 3.9 | Supported |
+| 20.0 | 3.10 | Supported |
+| 20.5 | 3.11 | Supported |
+| 21.0 | 3.11 | Supported |
+
+## Supported Renderers
+
+The submitter works with any Houdini render node connected to the Deadline Cloud ROP. Common renderers:
+- **Mantra** — Houdini's built-in renderer
+- **Karma** — Houdini's USD-based renderer (via Husk)
+- **Third-party** — Any renderer with a Houdini ROP node
+
+The adaptor does not need renderer-specific code. It delegates rendering to hython, which uses whatever render node is configured in the HIP file.

--- a/.kiro/powers/houdini-design-power/steering/design-doc-structure.md
+++ b/.kiro/powers/houdini-design-power/steering/design-doc-structure.md
@@ -1,0 +1,87 @@
+# Design Document Structure
+
+Every design document for deadline-cloud-for-houdini follows this 4-section format.
+
+## Template
+
+```markdown
+# Design: [Feature Name]
+
+**Author:** [Name]
+**Date:** [YYYY-MM-DD]
+**Status:** Draft | In Review | Approved | Implemented
+
+## 1. Problem Statement
+
+What problem are we solving? Who is affected? What is the current behavior
+and what is the desired behavior?
+
+Include:
+- User story or use case
+- Current limitations or pain points
+- Impact if not addressed
+
+## 2. Proposed Solution
+
+How do we solve it? Describe the approach at a level of detail sufficient
+for another engineer to implement it.
+
+Include:
+- High-level design
+- File changes required (list specific files)
+- API or interface changes
+- Data flow changes
+- Configuration changes (HDA parameters, JSON schemas, etc.)
+
+## 3. Implementation Plan
+
+Step-by-step plan for implementing the solution.
+
+Include:
+- Ordered list of changes
+- Test strategy (unit tests, integration tests, manual testing)
+- Migration or backward compatibility considerations
+- Rollout plan (if applicable)
+
+## 4. Alternatives Considered
+
+What other approaches were evaluated? Why were they rejected?
+
+For each alternative:
+- Brief description
+- Pros and cons
+- Reason for rejection
+```
+
+## Guidelines
+
+### Scope
+- One design document per feature or significant change
+- Small bug fixes do not need a design document
+- Changes to the HDA parameter interface always need a design document
+
+### File Location
+Store design documents in `docs/design/`:
+```
+docs/design/
+├── usd-scene-dependency-detection.md   # Existing example
+└── your-feature-name.md
+```
+
+### Level of Detail
+- **Problem Statement:** Concrete, with examples. "Users cannot submit USD scenes with external references" is better than "USD support is incomplete."
+- **Proposed Solution:** Specific enough to implement. Name the files, functions, and parameters that change.
+- **Implementation Plan:** Ordered steps. Each step should be a single commit or PR.
+- **Alternatives:** At least one alternative, even if it's "do nothing."
+
+### Review Process
+1. Write the design document
+2. Share with the team for review
+3. Iterate based on feedback
+4. Mark as "Approved" before starting implementation
+5. Update status to "Implemented" when done
+
+## Existing Design Documents
+
+Reference existing designs in `docs/design/` for style and depth:
+- `usd-scene-dependency-detection.md` — Example of a well-scoped design for asset detection

--- a/.kiro/powers/houdini-design-power/steering/design-workflow.md
+++ b/.kiro/powers/houdini-design-power/steering/design-workflow.md
@@ -1,0 +1,111 @@
+# Design Workflow
+
+Step-by-step workflow for designing features in deadline-cloud-for-houdini.
+
+## Step 1: Understand the Problem
+
+Before writing any design, answer these questions:
+- What user problem are we solving?
+- Which component is affected? (submitter, adaptor, HDA, or multiple)
+- What does the user's workflow look like today?
+- What should it look like after the change?
+
+Read the relevant source code:
+- Submitter: `src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/`
+- Adaptor: `src/deadline/houdini_adaptor/`
+- HDA: `src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/`
+
+## Step 2: Research
+
+### Houdini APIs
+- Check SideFX documentation: https://www.sidefx.com/docs/houdini/hom/hou/
+- Test API calls in Houdini's Python Shell (Windows → Python Shell)
+- Use hython for headless testing: `hython -c "import hou; ..."`
+
+### Deadline Cloud APIs
+- Check the `deadline` package source for available client methods
+- Review OpenJD job template specification
+- Check `openjd-adaptor-runtime` for adaptor lifecycle contracts
+
+### Existing Patterns
+- Look at how similar features work in other DCC integrations:
+  - [deadline-cloud-for-maya](https://github.com/aws-deadline/deadline-cloud-for-maya)
+  - [deadline-cloud-for-blender](https://github.com/aws-deadline/deadline-cloud-for-blender)
+  - [deadline-cloud-for-3ds-max](https://github.com/aws-deadline/deadline-cloud-for-3ds-max)
+
+## Step 3: Write the Design Document
+
+Follow the 4-section template in `design-doc-structure.md`:
+1. Problem Statement
+2. Proposed Solution
+3. Implementation Plan
+4. Alternatives Considered
+
+Save to `docs/design/your-feature-name.md`.
+
+## Step 4: Identify Affected Files
+
+For a typical submitter feature, you'll likely touch:
+
+| Change Type | Files |
+|-------------|-------|
+| New parameter | HDA `DialogScript`, `submitter.py` |
+| Asset detection | `_assets.py` |
+| Queue parameters | `queue_parameters.py` |
+| Job template | `submitter.py` |
+| UI change | `houdini_submitter_widget.py`, HDA `DialogScript` |
+| Adaptor behavior | `adaptor.py`, `houdini_handler.py` |
+| Adaptor schema | `schemas/init_data.schema.json` or `schemas/run_data.schema.json` |
+
+## Step 5: Plan Tests
+
+Every feature needs:
+- **Unit tests** — Test the logic in isolation using `mock_hou.py`
+- **Integration tests** — Test end-to-end with a real Houdini scene (if the feature affects submission or rendering)
+
+For submitter changes:
+- Add tests in `test/unit/deadline_submitter_for_houdini/`
+- Add a test scene in `test/integ/test_scripts/` if needed
+
+For adaptor changes:
+- Add tests in `test/unit/deadline_adaptor_for_houdini/`
+- Update adaptor integration tests if the lifecycle changes
+
+## Step 6: Review and Iterate
+
+1. Share the design document with the team
+2. Get feedback on the approach
+3. Revise based on feedback
+4. Get approval before implementing
+
+## Step 7: Implement
+
+Follow the implementation plan from the design document. Commit in logical steps:
+1. Add/modify the HDA parameter interface
+2. Implement the core logic
+3. Add unit tests
+4. Add integration tests
+5. Update documentation
+
+## Common Design Patterns
+
+### Adding a New Submitter Parameter
+1. Add parameter to HDA DialogScript (via Houdini UI)
+2. Read parameter value in `submitter.py`
+3. Map to OpenJD job template field
+4. Add unit test with mock parameter value
+5. Add integration test scene that uses the parameter
+
+### Modifying Asset Detection
+1. Identify the new file type or reference pattern
+2. Add detection logic to `_assets.py`
+3. Handle Houdini path variables (`$HIP`, `$JOB`)
+4. Add unit tests with mock scene data
+5. Add integration test with a scene containing the new reference type
+
+### Changing Adaptor Behavior
+1. Update JSON schema if init_data or run_data changes
+2. Modify `adaptor.py` lifecycle methods
+3. Update `houdini_handler.py` if new commands are needed
+4. Add unit tests for the new behavior
+5. Test with a real job submission

--- a/.kiro/powers/houdini-design-power/steering/external-references.md
+++ b/.kiro/powers/houdini-design-power/steering/external-references.md
@@ -1,0 +1,59 @@
+# External References
+
+## GitHub Repositories
+
+### This Project
+- **deadline-cloud-for-houdini:** https://github.com/aws-deadline/deadline-cloud-for-houdini
+
+### Core Libraries
+- **deadline-cloud:** https://github.com/aws-deadline/deadline-cloud — Client library, job attachments, GUI
+- **openjd-adaptor-runtime:** https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python — Adaptor lifecycle framework
+- **openjd-cli:** https://github.com/OpenJobDescription/openjd-cli — CLI for running adaptors locally
+- **openjd-sessions:** https://github.com/OpenJobDescription/openjd-sessions-for-python — Session management
+
+### Other DCC Integrations
+- **deadline-cloud-for-maya:** https://github.com/aws-deadline/deadline-cloud-for-maya
+- **deadline-cloud-for-blender:** https://github.com/aws-deadline/deadline-cloud-for-blender
+- **deadline-cloud-for-3ds-max:** https://github.com/aws-deadline/deadline-cloud-for-3ds-max
+- **deadline-cloud-for-nuke:** https://github.com/aws-deadline/deadline-cloud-for-nuke
+- **deadline-cloud-for-cinema-4d:** https://github.com/aws-deadline/deadline-cloud-for-cinema-4d
+- **deadline-cloud-for-unreal-engine:** https://github.com/aws-deadline/deadline-cloud-for-unreal-engine
+
+### Samples and Testing
+- **deadline-cloud-samples:** https://github.com/aws-deadline/deadline-cloud-samples — Sample job bundles, conda recipes, test infrastructure
+
+## SideFX Houdini Documentation
+
+### Python API (HOM)
+- **HOM Reference:** https://www.sidefx.com/docs/houdini/hom/hou/ — Complete `hou` module reference
+- **HOM Cookbook:** https://www.sidefx.com/docs/houdini/hom/cb/ — Python code examples
+- **hou.node:** https://www.sidefx.com/docs/houdini/hom/hou/node_.html — Node class reference
+- **hou.parm:** https://www.sidefx.com/docs/houdini/hom/hou/Parm.html — Parameter class reference
+- **hou.hipFile:** https://www.sidefx.com/docs/houdini/hom/hou/hipFile.html — HIP file operations
+
+### Houdini Concepts
+- **ROP Nodes:** https://www.sidefx.com/docs/houdini/nodes/out/index.html — Render output nodes
+- **Houdini Packages:** https://www.sidefx.com/docs/houdini/ref/plugins.html — Plugin/package system
+- **Digital Assets (HDA):** https://www.sidefx.com/docs/houdini/assets/index.html — HDA creation and management
+- **SOHO:** https://www.sidefx.com/docs/houdini/render/soho.html — Scripted output handler
+- **Network View:** https://www.sidefx.com/docs/houdini/network/navigate.html — Network navigation
+
+### USD in Houdini
+- **Solaris/USD:** https://www.sidefx.com/docs/houdini/solaris/index.html — USD workflow in Houdini
+- **Husk:** https://www.sidefx.com/docs/houdini/nodes/out/usdrender.html — USD render delegate
+
+## AWS Documentation
+
+### Deadline Cloud
+- **User Guide:** https://docs.aws.amazon.com/deadline-cloud/latest/userguide/
+- **API Reference:** https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/
+- **Developer Guide:** https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/
+
+### Open Job Description
+- **Specification:** https://github.com/OpenJobDescription/openjd-specifications — Job template format
+- **Template Schema:** https://github.com/OpenJobDescription/openjd-specifications/wiki — Schema documentation
+
+## Build Tools
+- **Hatch:** https://hatch.pypa.io/ — Build tool and environment manager
+- **hatch-vcs:** https://github.com/ofek/hatch-vcs — Version from git tags
+- **python-semantic-release:** https://python-semantic-release.readthedocs.io/ — Automated versioning

--- a/.kiro/powers/houdini-design-power/steering/hda-architecture.md
+++ b/.kiro/powers/houdini-design-power/steering/hda-architecture.md
@@ -1,0 +1,126 @@
+# HDA Architecture
+
+## What is the HDA?
+
+The Deadline Cloud ROP node is implemented as a Houdini Digital Asset (HDA). It lives at:
+```
+src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/
+```
+
+The HDA defines the node's parameter interface, callbacks, icon, and shelf tool. It is the primary UI surface for the submitter.
+
+## HDA File Structure
+
+```
+otls/deadline_cloud.hda/
+├── Sections.list                    # Top-level section index
+├── INDEX__SECTION                   # HDA index metadata
+├── houdini.hdalibrary               # Library marker (empty)
+└── Driver_1deadline__cloud/         # The ROP node type definition
+    ├── DialogScript                 # Parameter interface (27KB)
+    ├── PythonModule                 # Python callback code
+    ├── CreateScript                 # Node creation script
+    ├── OnCreated                    # Post-creation initialization
+    ├── IconSVG                      # Node icon (SVG)
+    ├── Tools.shelf                  # Shelf tool definition
+    ├── ExtraFileOptions             # File option metadata
+    ├── TypePropertiesOptions        # Type property settings
+    └── Sections.list                # Section index for this type
+```
+
+## Key Files
+
+### DialogScript (27KB)
+The largest and most important file. Defines every parameter the user sees on the ROP node:
+- Job name, description, priority
+- Frame range settings
+- Queue and farm selection
+- Job attachments configuration
+- Adaptor settings (Include Adaptor Wheels, etc.)
+- Render node connection settings
+
+The DialogScript uses Houdini's parameter definition language. Each parameter has a name, label, type, default value, and optional callback.
+
+### PythonModule
+Contains Python callback functions referenced by the DialogScript. Currently minimal — most logic lives in `submitter.py`.
+
+The PythonModule imports from `deadline_cloud_for_houdini` and delegates to the submitter module.
+
+### CreateScript
+Runs when the node type is first created. Sets up the initial node state.
+
+### OnCreated
+Runs after a node instance is created. Initializes default parameter values and connections.
+
+## How the HDA Loads
+
+1. Houdini scans `hpath` directories for `.hda` files
+2. The package JSON sets `hpath` to `$DEADLINE_CLOUD_FOR_HOUDINI`
+3. Houdini finds `otls/deadline_cloud.hda/` and registers the `Driver/deadline_cloud` type
+4. The node becomes available in the `/out` network TAB menu
+
+## Editing the HDA
+
+### Via Houdini UI (Recommended)
+1. Open Houdini
+2. Go to Assets → Asset Manager
+3. Under Operator Type Libraries → Current HIP File, find "Driver/deadline_cloud"
+4. Right-click → Type Properties
+5. **Parameter tab** — Edit the parameter interface (adds/removes/reorders parameters)
+6. Click Apply — the `DialogScript` file updates automatically
+7. The changes are written to the HDA source files in the repo
+
+### Via Direct File Edit (Advanced)
+You can edit `DialogScript` directly, but this is error-prone. The Houdini UI is the recommended approach because it validates the parameter definitions.
+
+Files you might edit directly:
+- `PythonModule` — Add or modify callback functions
+- `OnCreated` — Change post-creation initialization
+- `CreateScript` — Change type creation behavior
+
+## Parameter Interface Design
+
+### Parameter Naming Convention
+- Use lowercase with underscores: `job_name`, `frame_range`, `queue_id`
+- Prefix related parameters: `attachment_*`, `adaptor_*`
+
+### Parameter Types
+Common types used in the DialogScript:
+- `string` — Text input
+- `int` — Integer input
+- `toggle` — Boolean checkbox
+- `button` — Action button (triggers callback)
+- `menu` — Dropdown selection
+- `file` — File path with browser
+
+### Callbacks
+Parameters can trigger Python callbacks defined in PythonModule:
+```
+callback = "hou.phm().my_callback(kwargs)"
+```
+
+The `kwargs` dict contains:
+- `node` — The ROP node instance
+- `parm` — The parameter that triggered the callback
+- `script_value` — The new parameter value
+
+## Design Considerations
+
+### Adding Parameters
+When adding a new parameter to the HDA:
+1. Consider the parameter's position in the UI (group it with related parameters)
+2. Set a sensible default value
+3. Add help text (tooltip)
+4. If the parameter affects submission, update `submitter.py` to read it
+5. If the parameter needs validation, add a callback
+6. Add unit tests that mock the parameter value
+
+### Backward Compatibility
+- Never remove parameters without a deprecation period
+- Renamed parameters need migration logic in `OnCreated` or `CreateScript`
+- New parameters must have defaults that preserve existing behavior
+
+### Performance
+- Avoid expensive operations in parameter callbacks (they run on every change)
+- Defer API calls (like fetching queue parameters) to explicit user actions (button clicks)
+- Cache results where possible

--- a/.kiro/powers/houdini-design-power/steering/research-guide.md
+++ b/.kiro/powers/houdini-design-power/steering/research-guide.md
@@ -1,0 +1,160 @@
+# Houdini API Research Guide
+
+## How to Research Houdini APIs
+
+### 1. SideFX Documentation
+The primary reference for Houdini's Python API:
+- **HOM Reference:** https://www.sidefx.com/docs/houdini/hom/hou/
+- **HOM Cookbook:** https://www.sidefx.com/docs/houdini/hom/cb/
+
+### 2. Houdini Python Shell
+Test API calls interactively:
+1. Open Houdini
+2. Windows → Python Shell
+3. Type Python code directly
+
+### 3. hython (Headless)
+Test without the GUI:
+```bash
+hython -c "import hou; hou.hipFile.load('/path/to/scene.hip'); print(hou.node('/out').children())"
+```
+
+## Common API Patterns in This Project
+
+### Reading Node Parameters
+```python
+import hou
+
+node = hou.node("/out/deadline_cloud1")
+job_name = node.parm("job_name").eval()           # String value
+frame_start = node.parm("f1").eval()               # Float/int value
+use_custom = node.parm("use_custom_range").eval()  # Toggle (0 or 1)
+```
+
+### Finding Connected Nodes
+```python
+# Get the render node connected to the Deadline Cloud ROP
+node = hou.node("/out/deadline_cloud1")
+inputs = node.inputs()
+if inputs:
+    render_node = inputs[0]
+    print(render_node.type().name())  # e.g., "ifd" (Mantra), "usdrender" (Karma)
+```
+
+### Scanning for File References
+```python
+# Find all file references in a node
+node = hou.node("/obj/geo1")
+refs = node.references()  # Returns referenced nodes
+
+# Find file parameters
+for parm in node.parms():
+    template = parm.parmTemplate()
+    if template.type() == hou.parmTemplateType.String:
+        if template.stringType() == hou.stringParmType.FileReference:
+            value = parm.eval()
+            if value:
+                print(f"{parm.name()}: {value}")
+```
+
+### Working with HIP File
+```python
+import hou
+
+# Get current HIP file path
+hip_path = hou.hipFile.path()
+
+# Get HIP file variables
+hip_dir = hou.text.expandString("$HIP")
+job_dir = hou.text.expandString("$JOB")
+
+# Save HIP file
+hou.hipFile.save()
+```
+
+### Resolving Houdini Path Variables
+```python
+import hou
+
+# Expand variables like $HIP, $JOB, $HOUDINI_TEMP_DIR
+resolved = hou.text.expandString("$HIP/textures/wood.exr")
+
+# Expand channel references
+value = hou.text.expandString('`chs("/obj/geo1/file1/file")`')
+```
+
+### Working with Render Nodes
+```python
+import hou
+
+# Get all render nodes
+out_net = hou.node("/out")
+for child in out_net.children():
+    print(f"{child.name()} ({child.type().name()})")
+
+# Common render node types:
+# "ifd"        → Mantra
+# "usdrender"  → Karma/Husk
+# "rop_geometry" → Geometry ROP
+# "rop_alembic"  → Alembic ROP
+```
+
+### Frame Range
+```python
+import hou
+
+# Get global frame range
+start, end, step = hou.playbar.frameRange()
+
+# Get render node frame range
+node = hou.node("/out/mantra1")
+f1 = node.parm("f1").eval()  # Start frame
+f2 = node.parm("f2").eval()  # End frame
+f3 = node.parm("f3").eval()  # Frame step
+```
+
+## USD-Specific APIs
+
+### USD Scene Inspection
+```python
+import hou
+
+# Load a USD stage
+stage_node = hou.node("/stage/usdimport1")
+
+# Get the USD stage
+stage = stage_node.stage()
+
+# Traverse prims
+for prim in stage.Traverse():
+    print(prim.GetPath())
+
+# Find references
+for prim in stage.Traverse():
+    refs = prim.GetReferences()
+    for ref in refs.GetAddedOrExplicitItems():
+        if ref.assetPath:
+            print(f"Reference: {ref.assetPath}")
+```
+
+## Key `hou` Module Classes
+
+| Class | Purpose | Docs |
+|-------|---------|------|
+| `hou.node` | Access nodes in the scene | https://www.sidefx.com/docs/houdini/hom/hou/node_.html |
+| `hou.Parm` | Read/write parameter values | https://www.sidefx.com/docs/houdini/hom/hou/Parm.html |
+| `hou.hipFile` | HIP file operations | https://www.sidefx.com/docs/houdini/hom/hou/hipFile.html |
+| `hou.text` | String expansion, variable resolution | https://www.sidefx.com/docs/houdini/hom/hou/text.html |
+| `hou.NodeType` | Node type information | https://www.sidefx.com/docs/houdini/hom/hou/NodeType.html |
+| `hou.playbar` | Timeline/frame range | https://www.sidefx.com/docs/houdini/hom/hou/playbar.html |
+
+## Research Checklist
+
+When researching a Houdini API for a design:
+
+1. Find the relevant `hou` class in the SideFX docs
+2. Test the API call in Houdini's Python Shell
+3. Check if the API works in hython (headless) — some APIs require a GUI
+4. Check version compatibility (does it work in Houdini 19.5?)
+5. Look for existing usage in the codebase: `grep -r "hou.something" src/`
+6. Document the API call, its return type, and any edge cases

--- a/.kiro/powers/houdini-design-power/steering/submitter-architecture.md
+++ b/.kiro/powers/houdini-design-power/steering/submitter-architecture.md
@@ -1,0 +1,120 @@
+# Submitter Architecture
+
+## Overview
+
+The submitter is a Houdini plugin that provides a Deadline Cloud ROP (Render Output) node. It generates OpenJD job templates from Houdini scene data and submits them to AWS Deadline Cloud.
+
+## Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Houdini Session                           │
+│                                                             │
+│  ┌──────────────┐     ┌──────────────────────────────────┐  │
+│  │  ROP Network  │     │  Deadline Cloud ROP Node (HDA)   │  │
+│  │  (/out)       │────▶│                                  │  │
+│  │               │     │  DialogScript → Parameter UI     │  │
+│  │  Render Node  │     │  PythonModule → Callbacks        │  │
+│  │  (Mantra,     │     │  OnCreated   → Initialization    │  │
+│  │   Karma, etc) │     └──────────┬───────────────────────┘  │
+│  └──────────────┘                 │                          │
+│                                   ▼                          │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │              submitter.py                               │  │
+│  │  - Read ROP parameters                                  │  │
+│  │  - Detect connected render node                         │  │
+│  │  - Generate OpenJD job template                         │  │
+│  │  - Submit to Deadline Cloud API                         │  │
+│  └────────────┬───────────────────┬───────────────────────┘  │
+│               │                   │                          │
+│               ▼                   ▼                          │
+│  ┌────────────────────┐  ┌────────────────────────────────┐  │
+│  │    _assets.py       │  │   queue_parameters.py          │  │
+│  │  - Scan HIP scene   │  │  - Fetch queue params from API │  │
+│  │  - Find file refs   │  │  - Map to ROP parameters       │  │
+│  │  - Resolve $HIP etc │  │  - Handle param updates        │  │
+│  │  - USD dependencies │  └────────────────────────────────┘  │
+│  └────────────────────┘                                      │
+│                                                             │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  houdini_submitter_widget.py                            │  │
+│  │  - Qt widget wrapping Deadline Cloud submitter UI       │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Data Flow: Submit Job
+
+1. User clicks "Submit" on the Deadline Cloud ROP node
+2. `PythonModule` callback triggers `submitter.py`
+3. `submitter.py` reads all ROP node parameters via `hou.node().parm()`
+4. `submitter.py` detects the connected render node and its settings
+5. `_assets.py` scans the HIP scene for file dependencies
+6. `submitter.py` generates an OpenJD job template with steps and tasks
+7. The `deadline` library uploads job attachments and submits the job
+8. User sees confirmation with job ID
+
+## Data Flow: Save Bundle
+
+Same as Submit, but step 7 writes the job template and asset manifest to disk instead of submitting.
+
+## Key Data Structures
+
+### Job Template
+The submitter generates an OpenJD job template with:
+- **Job name** — From the ROP node parameter
+- **Steps** — One step per render node (or per frame range segment)
+- **Tasks** — One task per frame
+- **Environments** — Adaptor configuration, Houdini version
+- **Attachments** — HIP file and all detected dependencies
+
+### Asset List
+`_assets.py` returns a list of file paths that the HIP scene depends on:
+- Texture files
+- Geometry caches (`.bgeo`, `.abc`)
+- USD references and payloads
+- Simulation caches
+- HDRI environment maps
+
+## Plugin Loading
+
+The submitter loads via Houdini's package system:
+
+1. Houdini reads JSON files from `~/houdini{X.Y}/packages/`
+2. `deadline_submitter_for_houdini.json` sets:
+   - `DEADLINE_CLOUD_FOR_HOUDINI` → submitter source path
+   - `PYTHONPATH` → Python code + dependencies
+   - `hpath` → scanned for HDAs, panels, SOHO scripts
+3. Houdini loads the HDA from `otls/deadline_cloud.hda/`
+4. The Deadline Cloud ROP node becomes available in the `/out` network
+
+## File Responsibilities
+
+| File | Responsibility |
+|------|---------------|
+| `submitter.py` | Core logic: template generation, submit/save callbacks, render node detection |
+| `_assets.py` | Asset detection: file scanning, path resolution, USD dependency detection |
+| `queue_parameters.py` | Queue parameter fetch, mapping, and validation |
+| `houdini_submitter_widget.py` | Qt widget integration with Houdini's UI |
+| `hip_settings.py` | HIP file settings (save behavior, file path) |
+| `constants.py` | Shared constants (version strings, default values) |
+| `adaptor_override_environment.yaml` | Adaptor environment override configuration |
+| `submitter_panel.py` | Houdini panel registration |
+| `deadline_cloud_soho.py` | SOHO render output integration |
+
+## Extension Points
+
+### Adding a New Parameter
+1. Add to HDA DialogScript (via Houdini Type Properties UI)
+2. Read in `submitter.py` via `hou.node().parm("param_name").eval()`
+3. Map to job template field
+
+### Supporting a New File Type in Asset Detection
+1. Add detection logic to `_assets.py`
+2. Handle Houdini path variables (`$HIP`, `$JOB`, `$HOUDINI_TEMP_DIR`)
+3. Add unit test with mock scene data
+
+### Modifying Queue Parameter Behavior
+1. Update `queue_parameters.py`
+2. Ensure backward compatibility with existing queue configurations

--- a/.kiro/powers/houdini-dev-power/POWER.md
+++ b/.kiro/powers/houdini-dev-power/POWER.md
@@ -1,0 +1,119 @@
+---
+name: houdini-dev-power
+version: 1.0.0
+displayName: Houdini Dev Power
+description: Development power for deadline-cloud-for-houdini - build, test, debug, and implement features for the Houdini submitter and adaptor
+keywords:
+  - houdini
+  - deadline
+  - development
+  - testing
+  - submitter
+  - adaptor
+  - openjd
+  - hatch
+author: AWS Deadline Cloud Team
+---
+
+# Houdini Dev Power
+
+Development workflows for the deadline-cloud-for-houdini project. Covers building, testing, debugging, and implementing features for the Houdini submitter plugin and OpenJD adaptor.
+
+## Quick Start
+
+### Build
+```bash
+hatch build                                    # Build wheel + sdist
+hatch run install --houdini-version 21.0       # Install dev submitter
+```
+
+### Test
+```bash
+hatch run test                                 # Unit tests
+hatch run all:test                             # Unit tests across all Python versions
+hatch run integ:test                           # Integration tests (requires Houdini)
+hatch run integ:test_submitters                # Submitter integration tests only
+hatch run integ:test_adaptors                  # Adaptor integration tests only
+```
+
+### Lint and Format
+```bash
+hatch run lint                                 # ruff + black + mypy
+hatch run fmt                                  # Auto-format with black
+```
+
+### Build Adaptor Wheels
+```bash
+pip install build && ./scripts/build_wheels.sh
+```
+
+## Project Structure
+
+```
+src/deadline/
+├── houdini_submitter/                    # Houdini plugin (loaded by Houdini)
+│   ├── python/deadline_cloud_for_houdini/  # Submitter Python code
+│   │   ├── submitter.py                    # Core submission logic
+│   │   ├── _assets.py                      # Asset/file dependency detection
+│   │   ├── queue_parameters.py             # Queue parameter handling
+│   │   ├── houdini_submitter_widget.py     # Qt widget
+│   │   ├── hip_settings.py                 # HIP file settings
+│   │   └── constants.py                    # Constants
+│   ├── otls/deadline_cloud.hda/            # Houdini Digital Asset (ROP node)
+│   │   └── Driver_1deadline__cloud/        # HDA definition files
+│   ├── panel/submitter_panel.py            # Houdini panel
+│   └── soho/deadline_cloud_soho.py         # SOHO integration
+│
+└── houdini_adaptor/                      # OpenJD adaptor (pip-installable)
+    ├── HoudiniAdaptor/
+    │   ├── adaptor.py                      # Main adaptor (on_start, on_run, on_stop, on_cleanup)
+    │   ├── __main__.py                     # CLI entry point
+    │   └── schemas/                        # JSON schemas for init_data and run_data
+    └── HoudiniClient/
+        ├── houdini_client.py               # Client running inside Houdini
+        └── houdini_handler.py              # Command handler
+```
+
+## Two-Module Architecture
+
+1. **Submitter** (`houdini_submitter/`) — A Houdini plugin loaded via the Houdini package system. NOT pip-installable. Contains the ROP node (HDA), UI panel, and submission logic.
+
+2. **Adaptor** (`houdini_adaptor/`) — A standard pip-installable Python package. Provides the `houdini-openjd` CLI command. Runs on the render farm to execute Houdini renders via the OpenJD adaptor runtime lifecycle.
+
+## Development Workflows
+
+### Submitter Development
+1. Run `hatch run install --houdini-version X.Y` once
+2. Edit code in `src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/`
+3. Restart Houdini to pick up changes
+4. Run `hatch run test` to verify
+
+### Adaptor Development
+1. Build wheels: `pip install build && ./scripts/build_wheels.sh`
+2. In the Houdini submitter, enable "Include Adaptor Wheels" and point to `wheels/`
+3. Submit a test job to a service-managed fleet
+4. Run `hatch run test` to verify
+
+### HDA Development
+1. Open Houdini → Assets → Asset Manager
+2. Under Operator Type Libraries → Current HIP File, find "Driver/deadline_cloud"
+3. Right-click → Type Properties → Parameter tab
+4. Changes update `DialogScript` in the HDA source files
+
+## Key Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `hatch build` | Build wheel and sdist to `dist/` |
+| `hatch run test` | Run unit tests with coverage |
+| `hatch run all:test` | Run unit tests across Python 3.9-3.13 |
+| `hatch run integ:test` | Run all integration tests |
+| `hatch run integ:test_submitters` | Run submitter integration tests only |
+| `hatch run integ:test_adaptors` | Run adaptor integration tests only |
+| `hatch run lint` | Run ruff, black --check, mypy |
+| `hatch run fmt` | Auto-format code with black |
+| `hatch run install --houdini-version X.Y` | Install dev submitter for Houdini version |
+| `hatch run installer:build-installer` | Build standalone installer |
+| `hatch run test-installer` | Run installer tests |
+| `hatch shell` | Enter hatch shell environment |
+| `hatch env prune` | Delete all hatch environments |

--- a/.kiro/powers/houdini-dev-power/steering/build-and-test.md
+++ b/.kiro/powers/houdini-dev-power/steering/build-and-test.md
@@ -1,0 +1,150 @@
+# Build and Test Guide
+
+## Build
+
+### Build Wheel and Sdist
+```bash
+hatch build
+```
+Output: `dist/deadline_cloud_for_houdini-{VERSION}-py3-none-any.whl` and `.tar.gz`
+
+### Build Adaptor Wheels
+```bash
+pip install build
+./scripts/build_wheels.sh
+```
+Output: `wheels/` directory with wheels for `deadline_cloud_for_houdini`, `deadline`, and `openjd_adaptor_runtime`.
+
+### Build Standalone Installer
+```bash
+hatch run installer:build-installer --local-dev --platform <PLATFORM>
+# See full options: hatch run installer:build-installer -h
+```
+Requires InstallBuilder. Omit `--platform` to use the current platform.
+
+## Unit Tests
+
+### Run All Unit Tests
+```bash
+hatch run test
+```
+
+This runs pytest against `test/unit/` with:
+- Coverage for `src/deadline/houdini_adaptor` and `src/deadline/houdini_submitter`
+- Parallel execution via `pytest-xdist` (`--numprocesses=auto`)
+- Coverage threshold: 65% (configured in `pyproject.toml`)
+- HTML coverage report: `build/coverage/`
+
+### Run Across All Python Versions
+```bash
+hatch run all:test
+```
+Tests against Python 3.9, 3.10, 3.11, 3.12, 3.13.
+
+### Run Specific Test Files
+```bash
+hatch run test -- test/unit/deadline_submitter_for_houdini/test_assets.py
+hatch run test -- test/unit/deadline_adaptor_for_houdini/unit/HoudiniAdaptor/test_adaptor.py -v
+```
+
+### Run Tests Matching a Pattern
+```bash
+hatch run test -- -k "test_submit"
+```
+
+## Test Structure
+
+```
+test/
+├── unit/
+│   ├── test_copyright_headers.py                    # Copyright header validation
+│   ├── deadline_submitter_for_houdini/              # Submitter unit tests
+│   │   ├── test_assets.py                           # Asset detection
+│   │   ├── test_job_template.py                     # Job template generation
+│   │   ├── test_submit_callback.py                  # Submit callback
+│   │   ├── test_rops.py                             # ROP node tests
+│   │   ├── mock_hou.py                              # Mock for hou module
+│   │   └── conftest.py
+│   └── deadline_adaptor_for_houdini/unit/           # Adaptor unit tests
+│       ├── HoudiniAdaptor/
+│       │   ├── test_adaptor.py                      # Adaptor lifecycle tests
+│       │   └── test_adaptor_pathmapping.py          # Path mapping tests
+│       └── HoudiniClient/
+│           ├── test_client.py                       # Client tests
+│           ├── test_handler.py                      # Handler tests
+│           └── mock_hou.py                          # Mock for hou module
+├── integ/                                           # Integration tests
+│   ├── test_houdini_submitters.py                   # @pytest.mark.submitter
+│   ├── test_houdini_adaptors.py                     # @pytest.mark.adaptor
+│   └── test_scripts/                                # Test scene scripts
+└── installer/
+    └── test_installer.py                            # Installer tests
+```
+
+## Mocking the `hou` Module
+
+The `hou` module (Houdini's Python API) is only available inside a running Houdini session. Unit tests use `mock_hou.py` to mock it:
+
+- `test/unit/deadline_submitter_for_houdini/mock_hou.py` — Mocks for submitter tests
+- `test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py` — Mocks for adaptor client tests
+
+When writing new tests that import code using `hou`, ensure the mock is set up in `conftest.py` before the import.
+
+## Linting and Formatting
+
+### Check Style
+```bash
+hatch run lint
+```
+Runs:
+1. `ruff check .` — Linting (line-length 100, isort)
+2. `black --check --diff .` — Formatting check (line-length 100)
+3. `mypy src test` — Type checking
+
+### Auto-Format
+```bash
+hatch run fmt
+```
+Runs `black .` then `ruff check .`.
+
+## Coverage
+
+- Minimum threshold: **65%** (fails build if below)
+- Measured packages: `deadline/houdini_adaptor`, `deadline/houdini_submitter`
+- Reports: terminal, HTML (`build/coverage/`), XML (`build/coverage/coverage.xml`)
+- Omitted: `__main__.py`, `_version.py`
+
+## Installer Tests
+
+```bash
+hatch run test-installer
+```
+Requires a built installer in the repository root. Tests are in `test/installer/test_installer.py`.
+
+## Hatch Environments
+
+| Environment | Purpose | Key Scripts |
+|-------------|---------|-------------|
+| `default` | Unit tests, lint, format | `test`, `lint`, `fmt`, `install` |
+| `all` | Multi-Python matrix (3.9-3.13) | `test` |
+| `integ` | Integration tests | `test`, `test_submitters`, `test_adaptors` |
+| `integ-ci` | CI matrix (Houdini 19.5-21.0) | `setup`, `test` |
+| `installer` | Build standalone installer | `build-installer` |
+| `release` | Semantic release | `bump`, `version` |
+| `docs` | MkDocs documentation | `build`, `serve`, `deploy` |
+
+## Troubleshooting Build/Test Issues
+
+### Tests not picking up code changes
+```bash
+hatch env prune
+hatch run test
+```
+
+### `_version.py` not found
+```bash
+hatch build  # Generates _version.py via hatch-vcs
+```
+
+### Coverage report shows wrong files
+Coverage is configured in `pyproject.toml` under `[tool.coverage.run]` and `[tool.coverage.paths]`. Source packages: `deadline/houdini_adaptor`, `deadline/houdini_submitter`.

--- a/.kiro/powers/houdini-dev-power/steering/dev-guide.md
+++ b/.kiro/powers/houdini-dev-power/steering/dev-guide.md
@@ -1,0 +1,137 @@
+# Development Guide
+
+## Architecture Overview
+
+deadline-cloud-for-houdini has two modules:
+
+1. **Submitter** (`src/deadline/houdini_submitter/`) — Houdini plugin loaded via the Houdini package system. Provides the Deadline Cloud ROP node for submitting render jobs.
+
+2. **Adaptor** (`src/deadline/houdini_adaptor/`) — pip-installable Python package. Provides the `houdini-openjd` CLI for executing Houdini renders on the farm via the OpenJD adaptor runtime.
+
+## Namespace Packages
+
+This project uses Python namespace packages. The `deadline` package at `src/deadline/` has no `__init__.py`. Both `houdini_submitter` and `houdini_adaptor` are sub-packages under this namespace.
+
+The `hatch_custom_hook.py` build hook copies `_version.py` to three locations:
+- `src/deadline/houdini_adaptor/`
+- `src/deadline/houdini_submitter/`
+- `src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/`
+
+## Submitter Code Layout
+
+The submitter is NOT a standard pip package. It is loaded by Houdini's package system.
+
+```
+src/deadline/houdini_submitter/
+├── python/deadline_cloud_for_houdini/    # Main Python code
+│   ├── submitter.py          # Core: job template generation, submission callbacks
+│   ├── _assets.py            # Asset detection: finds file dependencies in HIP scenes
+│   ├── queue_parameters.py   # Queue parameter handling for Deadline Cloud
+│   ├── houdini_submitter_widget.py  # Qt widget for the submitter panel
+│   ├── hip_settings.py       # HIP file settings management
+│   ├── constants.py          # Shared constants
+│   └── adaptor_override_environment.yaml  # Adaptor override config
+├── otls/deadline_cloud.hda/  # Houdini Digital Asset (the ROP node)
+├── panel/submitter_panel.py  # Houdini panel registration
+└── soho/deadline_cloud_soho.py  # SOHO render output integration
+```
+
+### Key Submitter Files
+
+**`submitter.py`** (29KB) — The core of the submitter. Contains:
+- Job template generation from ROP node parameters
+- Submit and save-bundle callbacks
+- Render node detection and configuration
+- Step/task parameter mapping
+
+**`_assets.py`** (17KB) — Asset detection:
+- Scans HIP scene for file references
+- Handles Houdini-specific path variables (`$HIP`, `$JOB`)
+- Detects USD scene dependencies
+- Returns asset list for job attachments
+
+**`queue_parameters.py`** (15KB) — Queue parameter handling:
+- Reads queue parameters from Deadline Cloud API
+- Maps parameters to Houdini ROP node parameters
+- Handles parameter updates and validation
+
+## Adaptor Code Layout
+
+The adaptor is a standard pip-installable package with CLI entry points.
+
+```
+src/deadline/houdini_adaptor/
+├── HoudiniAdaptor/
+│   ├── adaptor.py        # Main adaptor: OpenJD lifecycle implementation
+│   ├── __main__.py       # CLI entry point for houdini-openjd
+│   ├── __init__.py       # Exports main() function
+│   └── schemas/          # JSON schemas
+│       ├── init_data.schema.json
+│       └── run_data.schema.json
+└── HoudiniClient/
+    ├── houdini_client.py   # Client that runs inside the Houdini process
+    ├── houdini_handler.py  # Handles commands sent from the adaptor
+    └── __init__.py
+```
+
+### Adaptor Lifecycle
+
+The adaptor implements the OpenJD adaptor runtime lifecycle:
+
+1. **`on_start`** — Launches hython, loads the HIP file, configures render settings
+2. **`on_run`** — Executes a render for a specific frame/task
+3. **`on_stop`** — Cleans up after rendering
+4. **`on_cleanup`** — Final cleanup, terminates hython process
+
+The adaptor communicates with the HoudiniClient running inside hython via a socket connection.
+
+### CLI Entry Points
+
+Defined in `pyproject.toml`:
+```
+houdini-openjd = "deadline.houdini_adaptor.HoudiniAdaptor:main"
+HoudiniAdaptor = "deadline.houdini_adaptor.HoudiniAdaptor:main"  # deprecated
+```
+
+## Dependencies
+
+From `pyproject.toml`:
+- `deadline` — AWS Deadline Cloud client library
+- `openjd-adaptor-runtime` — OpenJD adaptor runtime
+
+See `pyproject.toml` under `[project] dependencies` for current version constraints.
+
+## Code Style
+
+- **Line length:** 100 (ruff and black)
+- **Linter:** ruff with isort (known-first-party: `deadline`, `openjd`)
+- **Formatter:** black
+- **Type checker:** mypy (check_untyped_defs, namespace_packages)
+- **Copyright headers:** All source files must have Apache-2.0 headers (enforced by `test_copyright_headers.py`)
+
+## Branching Strategy
+
+- `mainline` — Active development. May break APIs at any time.
+- `release` — Official release for consumers. Breaking changes increment the interface version.
+
+## Versioning
+
+- Semantic versioning via `python-semantic-release`
+- Version source: git tags via `hatch-vcs`
+- Version scheme: `post-release` (e.g., `0.7.7.post67+gb392ccb47`)
+- Conventional commits determine version bumps
+
+## Adding New Features
+
+### Submitter Feature
+1. Modify code in `src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/`
+2. If adding parameters, update the HDA DialogScript
+3. Add unit tests in `test/unit/deadline_submitter_for_houdini/`
+4. Add integration test scene in `test/integ/test_scripts/` if needed
+5. Run `hatch run test` and `hatch run lint`
+
+### Adaptor Feature
+1. Modify code in `src/deadline/houdini_adaptor/`
+2. Update JSON schemas if init_data or run_data changes
+3. Add unit tests in `test/unit/deadline_adaptor_for_houdini/`
+4. Run `hatch run test` and `hatch run lint`

--- a/.kiro/powers/houdini-dev-power/steering/integration-testing.md
+++ b/.kiro/powers/houdini-dev-power/steering/integration-testing.md
@@ -1,0 +1,168 @@
+# Integration Testing Guide
+
+## Prerequisites
+
+Before running integration tests:
+
+1. **Houdini installed** with a valid license
+2. **Dev submitter installed:** `hatch run install --houdini-version X.Y`
+3. **Git LFS pulled:** `git lfs pull` (retrieves expected test images)
+4. **Logged out of Deadline Cloud Monitor:** `deadline auth logout`
+   - Running tests while logged in writes queue parameters to test job templates, which fails tests
+5. **Environment variables set:** `HYTHON_EXECUTABLE` and `HOUDINI_VERSION`
+
+## Environment Variables
+
+| Variable | Description | Example (Linux) |
+|----------|-------------|-----------------|
+| `HYTHON_EXECUTABLE` | Full path to hython binary | `/opt/hfs<VERSION>/bin/hython` |
+| `HOUDINI_VERSION` | Full Houdini version string | `<VERSION>` |
+
+### Setting Environment Variables
+
+**Linux:**
+```bash
+export HYTHON_EXECUTABLE="/opt/hfs<VERSION>/bin/hython"
+export HOUDINI_VERSION="<VERSION>"
+```
+
+**macOS:**
+```bash
+export HYTHON_EXECUTABLE="/Applications/Houdini/Houdini<VERSION>/Frameworks/Houdini.framework/Resources/bin/hython"
+export HOUDINI_VERSION="<VERSION>"
+```
+
+**Windows (PowerShell):**
+```powershell
+$Env:HYTHON_EXECUTABLE = "C:\Program Files\Side Effects Software\Houdini <VERSION>\bin\hython.exe"
+$Env:HOUDINI_VERSION = "<VERSION>"
+```
+
+### Windows: Install Dependencies into Houdini's Python
+
+On Windows, install test dependencies into Houdini's Python site-packages with Admin privileges:
+```powershell
+# Python version: 3.9 for 19.5, 3.10 for 20.0, 3.11 for 20.5/21.0
+pip install -r requirements-integ-dcc-env.txt --python-version=<PYTHON_VERSION> --only-binary=:all: --target="C:\Program Files\Side Effects Software\Houdini <VERSION>\python<PYTHON_VERSION_NO_DOT>\lib\site-packages"
+```
+
+Then run the pywin32 post-install script and grant permissions:
+```powershell
+# Run in elevated PowerShell
+& "<HOUDINI_PYTHON>/python.exe" "<HOUDINI_SITE_PACKAGES>/win32/scripts/pywin32_postinstall.py" -install
+icacls "<HOUDINI_SITE_PACKAGES>/win32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32_system32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32.pth" /grant "<YOUR_USER>:R"
+```
+
+## Running Integration Tests
+
+### All Integration Tests
+```bash
+hatch run integ:test
+```
+On Windows, you may need Admin privileges.
+
+### Submitter Tests Only
+```bash
+hatch run integ:test_submitters
+```
+Runs tests decorated with `@pytest.mark.submitter`.
+
+### Adaptor Tests Only
+```bash
+hatch run integ:test_adaptors
+```
+Runs tests decorated with `@pytest.mark.adaptor`.
+
+### Verbose Output
+```bash
+hatch run integ:test -- -v --tb=long
+```
+
+## Test Structure
+
+```
+test/integ/
+├── test_houdini_submitters.py    # Submitter integration tests
+├── test_houdini_adaptors.py      # Adaptor integration tests
+├── conftest.py                   # Shared fixtures
+├── helpers/
+│   ├── image_comparison.py       # Render output comparison
+│   └── test_runners.py           # Test execution helpers
+└── test_scripts/                 # Test scenes
+    ├── minimal_test/             # Basic render test
+    ├── render_dependencies_test/ # Multi-dependency render
+    ├── wedge_node_test/          # Wedge node variations
+    └── usd_scene_test/           # USD scene test
+```
+
+Each test script directory contains:
+- A scene script (`.py`) that creates a Houdini scene programmatically
+- An `expected_job_bundle/` directory with the expected OpenJD job template
+- Expected rendered images (stored in Git LFS)
+
+## How Integration Tests Work
+
+### Submitter Tests (`test_houdini_submitters.py`)
+1. Launch hython with the test scene script
+2. The script creates a Houdini scene, adds a Deadline Cloud ROP node, and saves a job bundle
+3. Compare the saved job bundle against the expected job bundle
+4. Compare rendered images against expected images
+
+### Adaptor Tests (`test_houdini_adaptors.py`)
+1. Use `openjd-cli` to run the adaptor with a test job bundle
+2. The adaptor launches hython, loads the scene, and renders
+3. Compare output against expected results
+
+## Multi-Version Testing
+
+### Manual Multi-Version Script
+Run integration tests across multiple Houdini versions:
+```bash
+python scripts/run_integ_tests.py '{"<VERSION_A>": "/opt/hfs<VERSION_A>/bin/hython", "<VERSION_B>": "/opt/hfs<VERSION_B>/bin/hython"}'
+```
+
+### CI Environment (`integ-ci`)
+The `integ-ci` hatch environment runs a matrix across Houdini versions. The specific versions are defined in `hatch.toml` under `[[envs.integ-ci.matrix]]`.
+
+```bash
+hatch build
+hatch run integ-ci:setup   # Downloads and installs Houdini from S3
+hatch run integ-ci:test
+```
+
+CI environment variables:
+- `INSTALLER_BUCKET` — S3 bucket with Houdini installers
+- `INSTALLER_BUCKET_EXPECTED_OWNER` — 12-digit AWS account ID owning the bucket
+
+## Job Bundle Integration Tests
+
+The `job_bundle_integ_tests/` directory contains an OpenJD job template for running integration tests on Service Managed Fleets:
+
+```bash
+deadline bundle submit --farm-id FARM_ID --queue-id QUEUE_ID job_bundle_integ_tests/
+```
+
+This template:
+1. Sets up the test environment (installs package, registers HDA)
+2. Runs submitter tests (`-m submitter`)
+3. Runs adaptor tests (`-m adaptor`)
+
+See `job_bundle_integ_tests/README.md` for details.
+
+## Troubleshooting
+
+### Tests fail with "queue parameters" errors
+Run `deadline auth logout` before testing. Being logged in causes queue parameters to leak into test job templates.
+
+### Image comparison failures
+1. Run `git lfs pull` to ensure expected images are downloaded
+2. Check that the Houdini version matches the expected images
+3. Small rendering differences across platforms are expected — check the tolerance thresholds
+
+### hython not found
+Verify `HYTHON_EXECUTABLE` points to the correct binary and the file is executable.
+
+### Permission denied on Windows
+Run PowerShell as Administrator for integration tests that need to write to Houdini's installation directory.

--- a/.kiro/powers/houdini-dev-power/steering/submitter-guide.md
+++ b/.kiro/powers/houdini-dev-power/steering/submitter-guide.md
@@ -1,0 +1,126 @@
+# Submitter Development Guide
+
+## Overview
+
+The Houdini submitter is a plugin that provides a Deadline Cloud ROP (Render Output) node. Users connect it to a render node in Houdini's `/out` network to submit render jobs to AWS Deadline Cloud.
+
+The submitter is NOT pip-installable. It is loaded by Houdini's package system via a JSON file that sets environment variables pointing to the source code.
+
+## Source Layout
+
+```
+src/deadline/houdini_submitter/
+├── python/deadline_cloud_for_houdini/
+│   ├── submitter.py                  # Core submission logic (29KB)
+│   ├── _assets.py                    # Asset/file dependency detection (17KB)
+│   ├── queue_parameters.py           # Queue parameter handling (15KB)
+│   ├── houdini_submitter_widget.py   # Qt widget for submitter panel
+│   ├── hip_settings.py               # HIP file settings
+│   ├── constants.py                  # Shared constants
+│   └── adaptor_override_environment.yaml
+├── otls/deadline_cloud.hda/          # Houdini Digital Asset
+│   └── Driver_1deadline__cloud/      # HDA definition
+│       ├── DialogScript              # Parameter interface definition
+│       ├── PythonModule              # Python callbacks
+│       ├── CreateScript              # Node creation script
+│       ├── OnCreated                 # Post-creation hook
+│       ├── IconSVG                   # Node icon
+│       └── Tools.shelf              # Shelf tool definition
+├── panel/submitter_panel.py          # Panel registration
+└── soho/deadline_cloud_soho.py       # SOHO integration
+```
+
+## Key Files
+
+### `submitter.py`
+The core of the submitter. Handles:
+- **Job template generation** — Converts ROP node parameters into an OpenJD job template
+- **Submit callback** — Called when the user clicks "Submit" in the UI
+- **Save bundle callback** — Called when the user clicks "Save Bundle"
+- **Render node detection** — Finds connected render nodes and their settings
+- **Step/task mapping** — Maps Houdini frame ranges to OpenJD steps and tasks
+
+### `_assets.py`
+Asset detection for job attachments:
+- Scans the HIP scene for file references using Houdini's `hou` API
+- Resolves Houdini path variables (`$HIP`, `$JOB`, `$HOUDINI_TEMP_DIR`)
+- Detects USD scene dependencies (references, payloads, sublayers)
+- Returns a list of files to upload as job attachments
+
+### `queue_parameters.py`
+Queue parameter handling:
+- Fetches queue parameters from the Deadline Cloud API
+- Maps Deadline Cloud parameters to Houdini ROP node parameters
+- Handles parameter updates when the user changes the target queue
+
+### `houdini_submitter_widget.py`
+Qt widget that wraps the Deadline Cloud submitter UI. Integrates with Houdini's Qt environment.
+
+## Houdini Package System
+
+The submitter is loaded via a JSON package file. The `hatch run install --houdini-version X.Y` command creates this file at:
+
+- **Linux:** `~/houdini{X.Y}/packages/deadline_submitter_for_houdini.json`
+- **macOS:** `~/Library/Preferences/houdini/{X.Y}/packages/deadline_submitter_for_houdini.json`
+- **Windows:** `%USERPROFILE%\Documents\houdini{X.Y}\packages\deadline_submitter_for_houdini.json`
+
+The JSON structure:
+```json
+{
+    "env": [
+        {"DEADLINE_CLOUD_FOR_HOUDINI": "/path/to/src/deadline/houdini_submitter"},
+        {"PYTHONPATH": "/path/to/python:/path/to/src:/path/to/plugin_env_X.Y"}
+    ],
+    "hpath": "$DEADLINE_CLOUD_FOR_HOUDINI"
+}
+```
+
+- `DEADLINE_CLOUD_FOR_HOUDINI` — Points to the submitter source directory
+- `PYTHONPATH` — Adds the Python code, source root, and plugin dependencies
+- `hpath` — Tells Houdini to scan this directory for HDAs, panels, SOHO scripts, etc.
+
+## HDA (Houdini Digital Asset)
+
+The Deadline Cloud ROP node is defined as an HDA at `otls/deadline_cloud.hda/Driver_1deadline__cloud/`.
+
+Key HDA files:
+- **DialogScript** — Defines the parameter interface (all the UI fields the user sees)
+- **PythonModule** — Python callbacks triggered by parameter changes and button clicks
+- **CreateScript** — Runs when the node is first created
+- **OnCreated** — Post-creation initialization
+
+To edit the HDA:
+1. Open Houdini
+2. Assets → Asset Manager
+3. Under Operator Type Libraries → Current HIP File, find "Driver/deadline_cloud"
+4. Right-click → Type Properties
+5. Edit parameters in the Parameter tab
+6. Click Apply — the DialogScript file updates automatically
+
+## Adding a New Submitter Parameter
+
+1. Edit the HDA DialogScript (via Houdini's Type Properties UI)
+2. Add the parameter read logic in `submitter.py`
+3. If the parameter affects job template generation, update the template logic
+4. If the parameter affects asset detection, update `_assets.py`
+5. Add unit tests for the new parameter
+6. Add an integration test scene if the parameter changes submission behavior
+
+## Testing the Submitter
+
+### Unit Tests
+```bash
+hatch run test -- test/unit/deadline_submitter_for_houdini/ -v
+```
+
+Tests use `mock_hou.py` to mock the `hou` module. The mock provides:
+- `hou.node()` — Returns mock nodes with parameter values
+- `hou.hipFile` — Mock HIP file operations
+- `hou.parm()` — Mock parameter access
+
+### Integration Tests
+```bash
+hatch run integ:test_submitters
+```
+
+Requires `HYTHON_EXECUTABLE` and `HOUDINI_VERSION` environment variables.

--- a/.kiro/powers/houdini-dev-power/steering/troubleshooting.md
+++ b/.kiro/powers/houdini-dev-power/steering/troubleshooting.md
@@ -1,0 +1,189 @@
+# Troubleshooting Guide
+
+## Build Issues
+
+### `hatch build` fails with version error
+**Cause:** `hatch-vcs` cannot determine version from git tags.
+**Fix:**
+```bash
+git fetch --tags
+hatch build
+```
+
+### `_version.py` not found
+**Cause:** The build hook hasn't run yet.
+**Fix:**
+```bash
+hatch build  # Generates _version.py and copies to all locations
+```
+
+### Build artifacts stale
+**Fix:**
+```bash
+rm -rf dist/ build/ *.egg-info
+hatch env prune
+hatch build
+```
+
+## Setup Issues
+
+### `hatch run install` fails with pip errors
+**Cause:** Network issues or invalid Houdini version string.
+**Fix:**
+- Verify version format: `X.Y` (e.g., `20.5`, not `20` or `20.5.487`)
+- Check network connectivity for pip downloads
+- Try: `hatch env prune` then retry
+
+### Plugin not visible in Houdini after `hatch run install`
+**Check:**
+1. Verify the package JSON exists:
+   ```bash
+   # Linux
+   cat ~/houdini21.0/packages/deadline_submitter_for_houdini.json
+   # macOS
+   cat ~/Library/Preferences/houdini/21.0/packages/deadline_submitter_for_houdini.json
+   ```
+2. Verify `plugin_env_21.0/` exists in the repo root and contains packages
+3. Restart Houdini completely (not just reload)
+4. In Houdini, check Windows → Shell and verify `PYTHONPATH` includes the plugin paths
+
+### `plugin_env_{X.Y}/` is empty or missing packages
+**Fix:**
+```bash
+rm -rf plugin_env_21.0/
+hatch run install --houdini-version 21.0
+```
+
+## Unit Test Issues
+
+### Tests fail with `ModuleNotFoundError: No module named 'hou'`
+**Cause:** Test is trying to import `hou` without the mock.
+**Fix:** Ensure `conftest.py` sets up the `mock_hou` module before any test imports. Check that `mock_hou.py` exists in the test directory.
+
+### Tests fail with import errors for `deadline` or `openjd`
+**Fix:**
+```bash
+hatch env prune
+hatch run test
+```
+
+### Coverage below 65%
+**Cause:** New code without tests, or test files not being collected.
+**Check:**
+- Coverage config in `pyproject.toml` under `[tool.coverage.run]`
+- Source packages: `deadline/houdini_adaptor`, `deadline/houdini_submitter`
+- Run with verbose coverage: `hatch run test -- --cov-report=term-missing`
+
+### `test_copyright_headers.py` fails
+**Cause:** Source file missing Apache-2.0 copyright header.
+**Fix:** Add the header to the file, or run:
+```bash
+./scripts/add_copyright_headers.sh
+```
+
+## Integration Test Issues
+
+### Tests fail with "queue parameters" in job template
+**Cause:** Logged into Deadline Cloud Monitor during test run.
+**Fix:**
+```bash
+deadline auth logout
+hatch run integ:test
+```
+
+### `HYTHON_EXECUTABLE` not set
+**Fix:** Set the environment variable to the full path of your hython binary:
+```bash
+# Linux
+export HYTHON_EXECUTABLE="/opt/hfs<VERSION>/bin/hython"
+# macOS
+export HYTHON_EXECUTABLE="/Applications/Houdini/Houdini<VERSION>/Frameworks/Houdini.framework/Resources/bin/hython"
+```
+```powershell
+# Windows
+$Env:HYTHON_EXECUTABLE = "C:\Program Files\Side Effects Software\Houdini <VERSION>\bin\hython.exe"
+```
+
+### Image comparison failures
+1. Run `git lfs pull` to download expected images
+2. Check that the Houdini version matches what the expected images were rendered with
+3. Platform differences in rendering are expected — check tolerance thresholds in `test/integ/helpers/image_comparison.py`
+
+### Permission denied on Windows
+Integration tests may need to write to Houdini's installation directory. Run PowerShell as Administrator.
+
+### hython crashes or hangs
+- Check Houdini license: `hython -c "import hou; print(hou.licenseCategory())"`
+- Verify Houdini version matches `HOUDINI_VERSION` env var
+- Check for conflicting Houdini environment variables
+
+## Adaptor Issues
+
+### `houdini-openjd` command not found
+**Cause:** The adaptor package is not installed in the current environment.
+**Fix:**
+```bash
+pip install -e .
+# or
+hatch shell
+houdini-openjd --help
+```
+
+### Adaptor fails to launch hython
+**Check:**
+- `hython` is in PATH or `HYTHON_EXECUTABLE` is set
+- Houdini license is valid
+- The HIP file path in the job template is correct
+
+### Adaptor socket connection errors
+**Cause:** The HoudiniClient inside hython failed to connect to the adaptor.
+**Check:**
+- Firewall rules (the adaptor uses localhost sockets)
+- hython process started successfully (check adaptor logs)
+
+## Hatch Environment Issues
+
+### Environments corrupted or stale
+```bash
+hatch env prune  # Delete all environments
+hatch run test   # Recreates default environment
+```
+
+### Wrong Python version
+```bash
+hatch env show   # Shows which Python each environment uses
+```
+
+### `hatch shell` doesn't set expected variables
+The `hatch shell` environment sets `MAYA_ENV_DIR` to `plugin_env/` — this is a legacy reference. For Houdini, use `hatch run install --houdini-version X.Y` instead.
+
+## Platform-Specific Issues
+
+### Linux: Houdini not found at `/opt/hfs{VERSION}/`
+Houdini may be installed elsewhere. Find it:
+```bash
+find / -name "hython" -type f 2>/dev/null
+```
+
+### macOS: Framework path issues
+The hython path on macOS is deeply nested:
+```
+/Applications/Houdini/Houdini{VERSION}/Frameworks/Houdini.framework/Resources/bin/hython
+```
+
+### Windows: Long path issues
+Enable long paths in Windows if you encounter path length errors:
+```powershell
+# Run as Administrator
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+```
+
+### Windows: pywin32 required for adaptor
+The adaptor on Windows requires `pywin32`. After installing it into Houdini's Python site-packages, run the post-install script and grant permissions:
+```powershell
+# Run in elevated PowerShell after installing Houdini
+& "<HOUDINI_PYTHON>/python.exe" "<HOUDINI_SITE_PACKAGES>/win32/scripts/pywin32_postinstall.py" -install
+icacls "<HOUDINI_SITE_PACKAGES>/win32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32_system32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32.pth" /grant "<YOUR_USER>:R"
+```

--- a/.kiro/powers/houdini-dev-setup/POWER.md
+++ b/.kiro/powers/houdini-dev-setup/POWER.md
@@ -1,0 +1,161 @@
+---
+name: houdini-dev-setup
+version: 1.0.0
+displayName: Houdini Dev Setup
+description: Automated development environment setup for deadline-cloud-for-houdini - builds packages, installs dependencies, and configures environment variables
+keywords:
+  - houdini
+  - deadline
+  - setup
+  - build
+  - install
+  - environment
+  - development
+  - hatch
+  - openjd
+author: AWS Deadline Cloud Team
+---
+
+# Houdini Dev Setup Power
+
+Automated development environment setup for deadline-cloud-for-houdini project.
+
+## What This Power Does
+
+This power automates the complete development environment setup for working on the deadline-cloud-for-houdini project. It handles everything from reading documentation to building packages, installing dependencies, and configuring environment variables.
+
+## Setup Steps Performed
+
+1. **Documentation Review** - Reads README.md and DEVELOPMENT.md to understand project requirements
+2. **Houdini Detection** - Verifies Houdini installation and identifies version (19.5, 20.0, 20.5, or 21.0)
+3. **Hatch Installation** - Installs and configures Hatch build tool
+4. **Package Build** - Builds wheel and source distributions with `hatch build`
+5. **Dev Submitter Installation** - Runs `hatch run install --houdini-version X.Y` to create Houdini package JSON and `plugin_env_{X.Y}/`
+6. **Wheel Build** - Builds adaptor wheels with `./scripts/build_wheels.sh`
+7. **OpenJD CLI Installation** - Installs openjd-cli for running integration tests
+8. **Test Packages Installation** - Installs pytest, coverage, and test dependencies
+9. **Git LFS Pull** - Retrieves expected test images for integration tests
+10. **Environment Configuration** - Sets up HYTHON_EXECUTABLE, HOUDINI_VERSION, and PATH
+
+## Prerequisites
+
+- Python 3.9 or higher installed on system
+- Houdini 19.5, 20.0, 20.5, or 21.0 installed with a valid license
+- Linux, macOS, or Windows operating system
+- Git LFS installed (for integration test images)
+
+## Houdini Version to Python Version Mapping
+
+| Houdini | Python |
+|---------|--------|
+| 19.5    | 3.9    |
+| 20.0    | 3.10   |
+| 20.5    | 3.11   |
+| 21.0    | 3.11   |
+
+## Usage
+
+The power will prompt you for:
+- **Houdini Version** (e.g., 19.5, 20.0, 20.5, 21.0)
+- **Houdini Installation Path** (if not in standard location)
+
+## What Gets Installed
+
+### System Python Packages
+- `hatch` - Build tool and environment manager
+
+### Plugin Environment (`plugin_env_{X.Y}/`)
+- `deadline` - AWS Deadline Cloud client library
+- `openjd-adaptor-runtime` - OpenJD adaptor runtime
+- All transitive dependencies (boto3, botocore, qtpy, psutil, etc.)
+
+### Development Packages
+- `openjd-cli` - OpenJD command-line interface
+- `pytest`, `pytest-cov`, `pytest-xdist` - Test framework and plugins
+- `coverage` - Code coverage measurement
+- `ruff`, `black`, `mypy` - Linting and formatting tools
+
+### Environment Variables
+- `HYTHON_EXECUTABLE` - Full path to hython binary
+- `HOUDINI_VERSION` - Full version string (e.g., `<MAJOR.MINOR.PATCH>`)
+- `PATH` - Adds Houdini bin directory
+
+## Platform-Specific Houdini Paths
+
+### Linux
+- Houdini install: `/opt/hfs{VERSION}/`
+- hython: `/opt/hfs{VERSION}/bin/hython`
+- User prefs: `~/houdini{MAJOR.MINOR}/`
+- Package JSON: `~/houdini{MAJOR.MINOR}/packages/deadline_submitter_for_houdini.json`
+
+### macOS
+- Houdini install: `/Applications/Houdini/Houdini{VERSION}/`
+- hython: `/Applications/Houdini/Houdini{VERSION}/Frameworks/Houdini.framework/Resources/bin/hython`
+- User prefs: `~/Library/Preferences/houdini/{MAJOR.MINOR}/`
+- Package JSON: `~/Library/Preferences/houdini/{MAJOR.MINOR}/packages/deadline_submitter_for_houdini.json`
+
+### Windows
+- Houdini install: `C:\Program Files\Side Effects Software\Houdini {VERSION}\`
+- hython: `C:\Program Files\Side Effects Software\Houdini {VERSION}\bin\hython.exe`
+- User prefs: `%USERPROFILE%\Documents\houdini{MAJOR.MINOR}\`
+- Package JSON: `%USERPROFILE%\Documents\houdini{MAJOR.MINOR}\packages\deadline_submitter_for_houdini.json`
+
+## After Setup
+
+Once setup is complete, you can:
+
+### Run Unit Tests
+```bash
+hatch run test
+```
+
+### Run Integration Tests
+```bash
+hatch run integ:test
+```
+
+### Build Package
+```bash
+hatch build
+```
+
+### Format and Lint Code
+```bash
+hatch run fmt
+hatch run lint
+```
+
+## Troubleshooting
+
+### Hatch Not Found
+Restart your terminal or add to PATH:
+```bash
+# Linux/macOS
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### hython Not Found
+Set HYTHON_EXECUTABLE to the full path of your hython binary. See Platform-Specific Houdini Paths above.
+
+### Plugin Not Loading in Houdini
+1. Verify the package JSON exists at the correct user prefs path
+2. Check that `plugin_env_{X.Y}/` was created in the repo root
+3. Restart Houdini after running `hatch run install`
+
+### Windows: pywin32 Required
+On Windows, after installing pywin32 into Houdini's Python site-packages, run the post-install script and grant permissions:
+```powershell
+# Run in elevated PowerShell after installing Houdini
+& "<HOUDINI_PYTHON>/python.exe" "<HOUDINI_SITE_PACKAGES>/win32/scripts/pywin32_postinstall.py" -install
+icacls "<HOUDINI_SITE_PACKAGES>/win32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32_system32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32.pth" /grant "<YOUR_USER>:R"
+```
+
+## Notes
+
+- Setup works on Linux, macOS, and Windows
+- The `hatch run install` command creates a Houdini package JSON pointing to the repo source — changes to code are live on next Houdini launch
+- The adaptor requires `hython` to be in PATH or `HYTHON_EXECUTABLE` set
+- Integration tests require `deadline auth logout` first to avoid queue parameter interference
+- Set `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` to access developer features (Include Adaptor Wheels)

--- a/.kiro/powers/houdini-dev-setup/steering/automated-setup.md
+++ b/.kiro/powers/houdini-dev-setup/steering/automated-setup.md
@@ -1,0 +1,258 @@
+# Houdini Dev Setup — Automated Workflow
+
+Complete automated setup workflow for deadline-cloud-for-houdini development environment.
+
+## Setup Workflow
+
+### Step 1: Prompt for Houdini Version
+
+Ask the user which version of Houdini to set up for:
+- Supported: 19.5, 20.0, 20.5, 21.0
+- Default: 21.0
+
+Example prompt:
+```
+Which version of Houdini would you like to set up for? (default: 21.0)
+```
+
+### Step 2: Verify Houdini Installation
+
+Check if Houdini is installed and hython is accessible.
+
+**Linux:**
+```bash
+test -x "/opt/hfs${VERSION}/bin/hython" && echo "Found" || echo "Not found"
+```
+
+**macOS:**
+```bash
+test -x "/Applications/Houdini/Houdini${VERSION}/Frameworks/Houdini.framework/Resources/bin/hython" && echo "Found" || echo "Not found"
+```
+
+**Windows (PowerShell):**
+```powershell
+Test-Path "C:\Program Files\Side Effects Software\Houdini ${VERSION}\bin\hython.exe"
+```
+
+If Houdini is NOT found, abort and instruct the user to install Houdini from [SideFX](https://www.sidefx.com/download/).
+
+If found, confirm the version and continue.
+
+### Step 3: Read Project Documentation
+
+Read and extract key information from:
+1. `README.md` - Project overview, compatibility, requirements
+2. `DEVELOPMENT.md` - Development workflow, build instructions
+
+### Step 4: Install Hatch
+
+Check if hatch is installed:
+```bash
+hatch --version
+```
+
+If not installed:
+```bash
+pip install hatch
+```
+
+Verify:
+```bash
+hatch --version
+hatch env show
+```
+
+### Step 5: Build the Package
+
+```bash
+hatch build
+```
+
+Expected output in `dist/`:
+- `deadline_cloud_for_houdini-{VERSION}-py3-none-any.whl`
+- `deadline_cloud_for_houdini-{VERSION}.tar.gz`
+
+### Step 6: Install Dev Submitter Plugin
+
+This creates a Houdini package JSON and installs dependencies into `plugin_env_{MAJOR.MINOR}/`:
+
+```bash
+hatch run install --houdini-version MAJOR.MINOR
+```
+
+For example:
+```bash
+hatch run install --houdini-version 21.0
+```
+
+This script (`scripts/install_dev_submitter.py`):
+1. Resolves dependencies from `pyproject.toml`
+2. Installs them into `plugin_env_{MAJOR.MINOR}/` using pip with `--platform` and `--python-version` flags
+3. Creates a Houdini package JSON at `~/houdini{MAJOR.MINOR}/packages/deadline_submitter_for_houdini.json` (Linux), `~/Library/Preferences/houdini/{MAJOR.MINOR}/packages/` (macOS), or `%USERPROFILE%\Documents\houdini{MAJOR.MINOR}\packages\` (Windows)
+
+The package JSON sets:
+- `DEADLINE_CLOUD_FOR_HOUDINI` → path to `src/deadline/houdini_submitter/`
+- `PYTHONPATH` → includes `python/`, `src/`, and `plugin_env_{MAJOR.MINOR}/`
+- `hpath` → `$DEADLINE_CLOUD_FOR_HOUDINI` (adds HDA and other Houdini resources)
+
+Verify by checking the JSON file exists:
+```bash
+# Linux
+cat ~/houdini21.0/packages/deadline_submitter_for_houdini.json
+
+# macOS
+cat ~/Library/Preferences/houdini/21.0/packages/deadline_submitter_for_houdini.json
+```
+
+### Step 7: Build Adaptor Wheels
+
+Build wheels for adaptor development workflow:
+```bash
+pip install build  # if not already installed
+./scripts/build_wheels.sh
+```
+
+Verify wheels exist:
+```bash
+ls ./wheels/
+# deadline_cloud_for_houdini-{VERSION}-py3-none-any.whl
+# deadline-{VERSION}-py3-none-any.whl
+# openjd_adaptor_runtime-{VERSION}-py3-none-any.whl
+```
+
+### Step 8: Install Test Dependencies
+
+Install test packages into the hatch environment:
+```bash
+hatch run sync  # installs requirements-testing.txt
+```
+
+For integration tests on **Windows**, install into Houdini's Python:
+```powershell
+# Python version: 3.9 for 19.5, 3.10 for 20.0, 3.11 for 20.5/21.0
+pip install -r requirements-integ-dcc-env.txt --python-version=<PYTHON_VERSION> --only-binary=:all: --target="C:\Program Files\Side Effects Software\Houdini <VERSION>\python<PYTHON_VERSION_NO_DOT>\lib\site-packages"
+```
+
+Then run the pywin32 post-install script and grant permissions:
+```powershell
+# Run in elevated PowerShell
+& "<HOUDINI_PYTHON>/python.exe" "<HOUDINI_SITE_PACKAGES>/win32/scripts/pywin32_postinstall.py" -install
+icacls "<HOUDINI_SITE_PACKAGES>/win32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32_system32" /grant "<YOUR_USER>:(OI)(CI)R" /T
+icacls "<HOUDINI_SITE_PACKAGES>/pywin32.pth" /grant "<YOUR_USER>:R"
+```
+
+### Step 9: Pull Git LFS Files
+
+Integration tests compare rendered output against expected images stored in Git LFS:
+```bash
+git lfs pull
+```
+
+### Step 10: Configure Environment Variables
+
+Set these environment variables for integration testing:
+
+**Linux:**
+```bash
+export HYTHON_EXECUTABLE="/opt/hfs<VERSION>/bin/hython"
+export HOUDINI_VERSION="<VERSION>"
+```
+
+**macOS:**
+```bash
+export HYTHON_EXECUTABLE="/Applications/Houdini/Houdini<VERSION>/Frameworks/Houdini.framework/Resources/bin/hython"
+export HOUDINI_VERSION="<VERSION>"
+```
+
+**Windows (PowerShell):**
+```powershell
+$Env:HYTHON_EXECUTABLE = "C:\Program Files\Side Effects Software\Houdini <VERSION>\bin\hython.exe"
+$Env:HOUDINI_VERSION = "<VERSION>"
+```
+
+### Step 11: Verify Installation
+
+Run unit tests to confirm everything works:
+```bash
+hatch run test
+```
+
+Expected: all tests pass, coverage ≥ 65%.
+
+Launch Houdini and verify the Deadline Cloud node appears:
+1. Open Houdini
+2. Go to Network View → `out` network
+3. Press TAB, type `deadline`
+4. The Deadline Cloud ROP node should appear
+
+## Post-Setup Configuration
+
+### Developer Options
+Set `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` to enable:
+- "Include Adaptor Wheels" option in the submitter
+- TEST button for local testing
+
+### Integration Test Prerequisite
+Before running integration tests, log out of Deadline Cloud Monitor:
+```bash
+deadline auth logout
+```
+Running tests while logged in causes queue parameters to be written to test job templates, which fails the tests.
+
+## Common Issues and Solutions
+
+### `hatch run install` fails with pip errors
+- Ensure you have network access for pip to download dependencies
+- Check that the Houdini version string is correct (e.g., `21.0`, not `21`)
+- Try `hatch env prune` and retry
+
+### Plugin not visible in Houdini
+- Verify the package JSON path matches your Houdini version
+- Check that `plugin_env_{MAJOR.MINOR}/` exists and contains packages
+- Restart Houdini completely (not just reload)
+
+### Unit tests fail with import errors
+- Run `hatch env prune` then `hatch run test` to recreate the environment
+- Ensure `_version.py` exists (run `hatch build` first)
+
+### Coverage below 65%
+- The coverage threshold is configured in `pyproject.toml` under `[tool.coverage.report]`
+- Coverage measures `src/deadline/houdini_adaptor` and `src/deadline/houdini_submitter`
+
+## Environment Variables Reference
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `HYTHON_EXECUTABLE` | Path to hython binary (integration tests) | `/opt/hfs<VERSION>/bin/hython` |
+| `HOUDINI_VERSION` | Full Houdini version (integration tests) | `<VERSION>` |
+| `DEADLINE_ENABLE_DEVELOPER_OPTIONS` | Enable dev features in submitter | `true` |
+| `DEADLINE_CLOUD_FOR_HOUDINI` | Set by package JSON — path to submitter source | (auto-set) |
+| `PYTHONPATH` | Set by package JSON — includes plugin_env and source | (auto-set) |
+
+## File Structure After Setup
+
+```
+deadline-cloud-for-houdini/
+├── dist/                          # Built wheel and sdist
+├── wheels/                        # Adaptor wheels for dev workflow
+├── plugin_env_21.0/               # Dependencies for Houdini 21.0
+│   ├── deadline/
+│   ├── openjd/
+│   ├── boto3/
+│   └── ...
+├── src/deadline/
+│   ├── houdini_submitter/         # Submitter plugin source
+│   └── houdini_adaptor/           # Adaptor source
+└── test/
+    ├── unit/                      # Unit tests
+    └── integ/                     # Integration tests
+```
+
+## Next Steps
+
+After setup is complete:
+1. Run `hatch run test` to verify unit tests pass
+2. Launch Houdini and verify the Deadline Cloud node loads
+3. For adaptor development, use `./scripts/build_wheels.sh` and "Include Adaptor Wheels" in the submitter
+4. For integration tests, see the integration-testing steering file in houdini-dev-power


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

   Engineers needed streamlined workflows for Houdini development with clear guidance on setup, design, implementation, and testing. 

   ### What was the solution? (How)

   Added three Kiro powers following the established pattern from other DCC integrations:

   **houdini-dev-setup** (2 files)
   - `POWER.md` — Setup power definition, prerequisites, platform-specific paths
   - `steering/automated-setup.md` — 11-step automated setup workflow

   **houdini-dev-power** (6 files)
   - `POWER.md` — Dev power definition, quick commands, project structure overview
   - `steering/build-and-test.md` — Build commands, test structure, coverage, hatch environments
   - `steering/dev-guide.md` — Two-module architecture, code layout, style conventions, versioning
   - `steering/integration-testing.md` — Prerequisites, env vars, multi-version testing
   - `steering/submitter-guide.md` — Submitter source layout, HDA editing, package system
   - `steering/troubleshooting.md` — Build, setup, test, adaptor, and platform-specific issues

   **houdini-design-power** (8 files)
   - `POWER.md` — Design power definition, quick start, architecture context
   - `steering/deadline-cloud-architecture.md` — System diagram, components, data flow
   - `steering/design-doc-structure.md` — 4-section design document template
   - `steering/design-workflow.md` — Step-by-step design process
   - `steering/external-references.md` — GitHub repos, SideFX docs, AWS docs
   - `steering/submitter-architecture.md` — Submitter component diagram, data flow, extension points
   - `steering/hda-architecture.md` — HDA file structure, editing workflow, parameter design
   - `steering/research-guide.md` — Houdini Python API patterns, hou module reference

   ### What is the impact of this change?

   - **Onboarding:** New engineers can set up a dev environment with a single prompt
   - **Development:** Guided workflows for submitter, adaptor, and HDA changes
   - **Design:** Consistent design document format and research workflow
   - **Consistency:** Follows the same 3-power pattern as Blender, 3ds Max, and Maya

   No code changes. Documentation and tooling only.

   ### How was this change tested?

   - ✅ All steering files validated for markdown format
   - ✅ All file paths, commands, and hatch scripts verified against DEVELOPMENT.md, pyproject.toml, and hatch.toml
   - ✅ Cross-references between powers verified
   - ✅ No hardcoded version numbers in commands or paths — uses placeholders throughout

   ### Was this change documented?

   Yes — this change IS documentation. Added 16 files of structured guidance covering setup, development, and design workflows.

   ### Is this a breaking change?

   No — documentation and tooling only. No changes to adaptor, submitter, or any code.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
