### PR TITLE
fix: match conda package houdini version to application houdini version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,6 +43,9 @@ This workflow creates a "houdini package", a JSON file which tells Houdini where
    ```sh
    git clone git@github.com:aws-deadline/deadline-cloud-for-houdini.git
    cd deadline-cloud-for-houdini
+
+   # Fetch tags to ensure the correct openjd version is detected
+   git fetch --tags
    ```
 
 2. Create a Houdini package using the provided script, specifying the full houdini version:

--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/ExtraFileOptions
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/ExtraFileOptions
@@ -19,6 +19,26 @@
 		"type":"string",
 		"value":""
 	},
+	"OnLoaded/Cursor":{
+		"type":"intarray",
+		"value":[15,33]
+	},
+	"OnLoaded/IsExpr":{
+		"type":"bool",
+		"value":false
+	},
+	"OnLoaded/IsPython":{
+		"type":"bool",
+		"value":true
+	},
+	"OnLoaded/IsScript":{
+		"type":"bool",
+		"value":true
+	},
+	"OnLoaded/Source":{
+		"type":"string",
+		"value":""
+	},
 	"PythonModule/Cursor":{
 		"type":"intarray",
 		"value":[6,1]

--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/OnLoaded
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/OnLoaded
@@ -1,0 +1,9 @@
+# OnCreated only fires for new nodes; OnLoaded fires when a scene is opened,
+# ensuring queue parameters (e.g. CondaPackages version) stay current.
+from botocore.exceptions import CredentialRetrievalError
+
+try:
+    node = kwargs['node']
+    node.hdaModule().update_queue_parameters_callback(kwargs)
+except CredentialRetrievalError as e:
+    print(e)

--- a/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/Sections.list
+++ b/src/deadline/houdini_submitter/otls/deadline_cloud.hda/Driver_1deadline__cloud/Sections.list
@@ -7,4 +7,5 @@ Tools.shelf	Tools.shelf
 IconSVG	IconSVG
 PythonModule	PythonModule
 OnCreated	OnCreated
+OnLoaded    OnLoaded
 ExtraFileOptions	ExtraFileOptions

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/queue_parameters.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import json
+import re
 from typing import Any, Optional, Union
 
 import hou
@@ -357,6 +358,18 @@ def _rebuild_queue_parameters_ui(
 def _restore_queue_parameter_values(
     node: hou.Node, existing_values: dict[str, Union[float, int, str]]
 ) -> None:  # pragma: no cover
+
+    # Override the ApplicationVersion to the current Houdini version the scene is opened in
+    conda_value: Optional[Union[str, float, int]] = existing_values.pop("CondaPackages", None)
+    if conda_value is not None:
+        conda_parm = node.parm(_get_prefixed_name("CondaPackages"))
+        if conda_parm is not None and isinstance(conda_value, str):
+            houdini_version: str = ".".join(hou.applicationVersionString().split(".")[:2])
+            updated: str = re.sub(
+                r"(?<!\S)houdini=\S+", f"houdini={houdini_version}.*", conda_value
+            )
+            conda_parm.set(updated)
+
     for name, value in existing_values.items():
         parm = node.parm(_get_prefixed_name(name))
         if parm is not None:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/185
### What was the problem/requirement? (What/Why)
The pre-populated text with the version of Houdini conda package in the submitter is not updated when you open files between Houdini versions.


When a scene is saved, Houdini persists the CondaPackages spare parameter value (e.g. houdini=20.0.*) in the .hip
file. When that scene is later opened in a different Houdini version (e.g. 20.5), Houdini restores the saved value
as-is — there was no callback on scene load to update it to match the running version.

### What was the solution? (How)
 Add an `OnLoaded` event script that triggers `update_queue_parameters_callback` when a scene is opened. Inside
`update_queue_parameters`, the CondaPackages value is now updated to replace the houdini= version with the
current running Houdini version, rather than restoring the stale saved value. This requires API credentials to be
available at scene load time.
If no credential is available, the version will be updated whenever there is a `call_back` that successfully triggers `update_queue_parameters`
### What is the impact of this change?
The pre-populated text with the version of Houdini conda package in the submitter match running Houdini version

### How was this change tested?
Created a Houdini scene with a deadline node in Houdini 19.5 and 20.5, verify that when opening them in Houdini 21, the Houdini version in Conda Package field got updated correctly.
`hatch run test:all` and all unit test passed.

#### Please run the integration tests and paste the results below.
3 failed, 4 passed in 192.31s (0:03:12)
All submitter test passed. All adaptor test fail due to no mantra/karma license in local environment.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
installer/ was not changed

### Was this change documented?
I only add instruction in `DEVELOPMENT.md` to fetch git tag so that the correct openjd is detected 

### Is this a breaking change?
Not a breaking change. User can edit the package version if they want before submitting a job

----
