### PR TITLE
test(integ): verify adaptor keeps dcc loaded between tasks

### DIFF
--- a/test/integ/test_houdini_adaptors.py
+++ b/test/integ/test_houdini_adaptors.py
@@ -1,5 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import json
+import os
+import re
+
 import pytest
 
 from pathlib import Path
@@ -91,3 +95,84 @@ class TestAdaptors:
         assert_all_images_close(
             script_location / "render_dependencies_test" / "expected_images", tmp_path
         )
+
+    def test_adaptor_keeps_dcc_open_between_tasks(
+        self,
+        hython_location: Path,
+        script_location: Path,
+        tmp_path: Path,
+    ) -> None:
+        """
+        Verifies that the Houdini adaptor keeps the DCC open between tasks within a single
+        step session. The adaptor should call 'daemon start' once, 'daemon run' for each task,
+        and 'daemon stop' once — proving Houdini was NOT restarted between tasks.
+
+        Uses a Geometry ROP to avoid requiring a render license (e.g. mantra).
+        """
+        # Determine Houdini version from the hython path or env
+        houdini_version = os.environ.get("HOUDINI_VERSION", "")
+        if not houdini_version:
+            match = re.search(r"[Hh]oudini[/\\]?(\d+\.\d+)", str(hython_location))
+            if match:
+                houdini_version = match.group(1)
+
+        if not houdini_version:
+            pytest.fail(
+                "Could not determine Houdini version. Set HOUDINI_VERSION env var "
+                f"or ensure hython path contains version info. Path: {hython_location}"
+            )
+
+        # Create a HIP file with a Geometry ROP (no render license needed)
+        hip_output = run_command(
+            [
+                str(hython_location),
+                str(script_location / "dcc_open_test" / "_test_hip.py"),
+                "--",
+                str(tmp_path),
+            ]
+        )
+        assert hip_output.returncode == 0, "Failed to create test HIP file"
+
+        job_template_location = script_location / "dcc_open_test" / "template.yaml"
+        job_params = {
+            "HipFile": str(tmp_path / "test_dcc_open.hip"),
+            "HoudiniVersion": houdini_version,
+        }
+
+        # Run the step with all tasks in a single session (frames 1-3)
+        output = run_command(
+            [
+                "openjd",
+                "run",
+                str(job_template_location),
+                "--step",
+                "GeoRender",
+                "--job-param",
+                json.dumps(job_params),
+            ]
+        )
+        assert output.returncode == 0
+
+        # Combine stdout and stderr for lifecycle assertion
+        combined_output = output.stdout.decode("utf-8", errors="replace") + output.stderr.decode(
+            "utf-8", errors="replace"
+        )
+
+        # Verify the hython process was launched exactly once. The adaptor logs
+        # "Running command: <hython_path>" when it starts hython. If the adaptor
+        # restarted Houdini between tasks, we'd see this repeated.
+        hython_launches = combined_output.count("ADAPTOR_OUTPUT: INFO: Running command:")
+        assert hython_launches == 1, (
+            f"Expected hython to be launched exactly once but found {hython_launches} "
+            "launches. Houdini was restarted between tasks."
+        )
+
+        # Verify all 3 tasks rendered successfully within the single session
+        assert combined_output.count("Finished Rendering") == 3, (
+            "Expected 3 'Finished Rendering' messages (one per task) but got "
+            f"{combined_output.count('Finished Rendering')}."
+        )
+
+        # Verify the session structure: one enter, one exit
+        assert combined_output.count("Entering Environment") == 1
+        assert combined_output.count("Exiting Environment") == 1

--- a/test/integ/test_scripts/dcc_open_test/_test_hip.py
+++ b/test/integ/test_scripts/dcc_open_test/_test_hip.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Creates a minimal HIP file with a Geometry ROP for testing adaptor session persistence
+without requiring a render license (mantra).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import hou
+
+
+def save_as_hip(output_dir: str) -> None:
+    hou.hipFile.setName("test_dcc_open.hip")
+    # Create a geometry ROP - has standard render parms (trange) but doesn't need mantra
+    geo_node = hou.node("/obj").createNode("geo", "test_geo")
+    geo_node.createNode("box", "box1")
+    rop = hou.node("/out").createNode("geometry", "geo_rop")
+    rop.parm("soppath").set("/obj/test_geo/box1")
+    rop.parm("sopoutput").set(f"{output_dir}/output.$F4.bgeo.sc")
+    hou.hipFile.save(str(Path(output_dir).joinpath(hou.hipFile.basename())))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir")
+    args = parser.parse_args(args=sys.argv[sys.argv.index("--") :])
+    save_as_hip(args.output_dir)

--- a/test/integ/test_scripts/dcc_open_test/template.yaml
+++ b/test/integ/test_scripts/dcc_open_test/template.yaml
@@ -1,0 +1,80 @@
+specificationVersion: jobtemplate-2023-09
+name: test_dcc_open
+parameterDefinitions:
+- name: HipFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+- name: HoudiniVersion
+  type: STRING
+steps:
+- name: GeoRender
+  stepEnvironments:
+  - name: Houdini
+    description: Runs Houdini in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          ignore_input_nodes: true
+          render_node: /out/geo_rop
+          scene_file: '{{Param.HipFile}}'
+          version: '{{Param.HoudiniVersion}}'
+          wedge_node: ''
+          wedgenum: ''
+      actions:
+        onEnter:
+          command: houdini-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
+        onExit:
+          command: houdini-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame_range:
+          end: {{Task.Param.Frame}}
+          start: {{Task.Param.Frame}}
+          step: 1
+        ignore_input_nodes: true
+        render_node: /out/geo_rop
+    actions:
+      onRun:
+        command: houdini-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      range: 1-3:1
+      type: INT


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We needed a test to validate that the adaptor keeps the dcc open between tasks.

### What was the solution? (How)

I added a test which runs 3 tasks through a single adaptor session using a lightweight Geometry ROP and asserts that hython was launched exactly once, confirming the DCC process persisted across tasks.

### What is the impact of this change?

We now have a test that verifies the adaptor keeps the dcc open between tasks.

### How was this change tested?

ran the tests

#### Please run the integration tests and paste the results below.

```
hatch run integ:test -k test_adaptor_keeps_dcc_open_between_tasks
=========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.13.5, pytest-8.4.2, pluggy-1.6.0 -- /.../hatch/env/virtual/deadline-cloud-for-houdini/-a1nZqww/integ/bin/python
cachedir: .pytest_cache
rootdir: /.../deadline-cloud-for-houdini
configfile: pyproject.toml
testpaths: test
plugins: cov-7.1.0, xdist-3.8.0
1 worker [1 item]
scheduling tests via LoadScheduling

test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_keeps_dcc_open_between_tasks
[gw0] [100%] PASSED test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_keeps_dcc_open_between_tasks

=========================================================================================== slowest 5 durations ===========================================================================================
28.27s call     test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_keeps_dcc_open_between_tasks
0.00s setup    test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_keeps_dcc_open_between_tasks
0.00s teardown test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_keeps_dcc_open_between_tasks
=========================================================================================== 1 passed in 29.84s ============================================================================================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

### Was this change documented?

n/a

### Is this a breaking change?

no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
