### PR TITLE
fix: parse sublayer nodes for path mapping properly

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover
     raise OSError("Could not find the Houdini module. Are you running this inside of Houdini?")
 
 if TYPE_CHECKING:  # pragma: no cover
-    from hou import Node
+    from hou import Node, Parm, ParmTemplate
 
 
 class HoudiniHandler:
@@ -65,6 +65,39 @@ class HoudiniHandler:
 
         # Reload the env variables
         hou.hscript("varchange")
+
+    def _remap_lop_file_paths(self) -> None:
+        """
+        Applies HOUDINI_PATHMAP to LOP node file path parameters.
+
+        HOUDINI_PATHMAP does not apply to USD/LOP nodes (sublayer, reference, etc.)
+        because USD asset resolution uses ArResolver, not Houdini's file I/O layer.
+        This method manually remaps any file reference string parms on LOP nodes.
+        """
+        if not os.environ.get("HOUDINI_PATHMAP"):
+            return
+
+        lop_nodes: list[Node] = hou.node("/").recursiveGlob("*", filter=hou.nodeTypeFilter.Lop)
+        for node in lop_nodes:
+            parms: list[Parm] = node.parms()
+            for parm in parms:
+                template: ParmTemplate = parm.parmTemplate()
+                if template.type() != hou.parmTemplateType.String:
+                    continue
+                if (
+                    template.stringType() == hou.stringParmType.FileReference
+                    or parm.name().startswith("filepath")
+                ):
+                    original: str = parm.unexpandedString()
+                    if not original or original.startswith("$") or original.startswith("`"):
+                        continue
+                    mapped, err = hou.hscript(f"pathmap -t '{original}' -c")
+                    mapped = mapped.strip()
+                    if err:
+                        print(f"Error remapping {parm.path()}: {err}")
+                    elif mapped and mapped != original:
+                        parm.set(mapped)
+                        print(f"Remapped LOP parm {parm.path()}: " f"{original} -> {mapped}")
 
     def set_node_settings(self, node):
         # this is a place holder function
@@ -236,3 +269,4 @@ class HoudiniHandler:
             print(e)
 
         self._path_map_envs()
+        self._remap_lop_file_paths()

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py
@@ -20,3 +20,6 @@ setattr(this_module, "hscript", Mock(name=module_name + ".hscript"))
 setattr(
     this_module, "applicationVersionString", Mock(name=module_name + ".applicationVersionString")
 )
+setattr(this_module, "nodeTypeFilter", Mock(name=module_name + ".nodeTypeFilter"))
+setattr(this_module, "parmTemplateType", Mock(name=module_name + ".parmTemplateType"))
+setattr(this_module, "stringParmType", Mock(name=module_name + ".stringParmType"))

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from .mock_hou import hou_module as hou
@@ -256,3 +256,126 @@ class TestHoudiniHandler:
 
         out, _ = capfd.readouterr()
         assert "Enabled Alfred style progress\n" not in out
+
+
+class TestRemapLopFilePaths:
+    """Tests for HoudiniHandler._remap_lop_file_paths (fix for issue #314)"""
+
+    def _setup_lop_nodes(self, parms):
+        """Helper to mock hou.node('/').recursiveGlob returning nodes with given parms."""
+        mock_node = Mock()
+        mock_node.parms.return_value = parms if isinstance(parms, list) else [parms]
+        mock_root = MagicMock()
+        mock_root.recursiveGlob.return_value = [mock_node]
+        hou.node.return_value = mock_root
+        return mock_node
+
+    def _make_parm(self, name, string_type, unexpanded_string):
+        """Helper to create a mock parm with template metadata."""
+        parm = Mock(name=f"parm_{name}")
+        parm.name.return_value = name
+        parm.path.return_value = f"/stage/node/{name}"
+        parm.unexpandedString.return_value = unexpanded_string
+        template = Mock()
+        template.type.return_value = hou.parmTemplateType.String
+        template.stringType.return_value = string_type
+        parm.parmTemplate.return_value = template
+        return parm
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_early_return_no_pathmap(self):
+        """Does nothing when HOUDINI_PATHMAP is not set."""
+        handler = HoudiniHandler()
+        handler._remap_lop_file_paths()
+        hou.node.assert_not_called()
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_remaps_file_reference_parm(self, capfd):
+        """Remaps parms with stringType == FileReference (sublayer case)."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, "/src/asset.usd")
+        self._setup_lop_nodes(parm)
+        hou.hscript.return_value = ("/dest/asset.usd\n", "")
+
+        handler._remap_lop_file_paths()
+
+        parm.set.assert_called_once_with("/dest/asset.usd")
+        out, _ = capfd.readouterr()
+        assert "/src/asset.usd -> /dest/asset.usd" in out
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_remaps_filepath_named_parm_not_tagged_as_file_reference(self, capfd):
+        """Remaps parms named 'filepath*' even if stringType is Regular (reference node case)."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.Regular, "/src/model.usd")
+        self._setup_lop_nodes(parm)
+        hou.hscript.return_value = ("/dest/model.usd\n", "")
+
+        handler._remap_lop_file_paths()
+
+        parm.set.assert_called_once_with("/dest/model.usd")
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_skips_empty_parm_values(self):
+        """Does not call hscript for empty parm values."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, "")
+        self._setup_lop_nodes(parm)
+
+        handler._remap_lop_file_paths()
+
+        hou.hscript.assert_not_called()
+        parm.set.assert_not_called()
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    @pytest.mark.parametrize("expression", ["$HIP/assets/mesh.usd", "`chs('path')`"])
+    def test_skips_expression_parms(self, expression):
+        """Does not remap parms starting with $ or backtick (expression-based paths)."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, expression)
+        self._setup_lop_nodes(parm)
+
+        handler._remap_lop_file_paths()
+
+        hou.hscript.assert_not_called()
+        parm.set.assert_not_called()
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_skips_non_string_parms(self):
+        """Ignores non-String parm types (int, float, etc.)."""
+        handler = HoudiniHandler()
+        parm = Mock(name="int_parm")
+        template = Mock()
+        template.type.return_value = hou.parmTemplateType.Int
+        parm.parmTemplate.return_value = template
+        self._setup_lop_nodes(parm)
+
+        handler._remap_lop_file_paths()
+
+        hou.hscript.assert_not_called()
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_no_op_when_path_unchanged(self):
+        """Does not call parm.set when pathmap returns the same path."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, "/other/path.usd")
+        self._setup_lop_nodes(parm)
+        hou.hscript.return_value = ("/other/path.usd\n", "")
+
+        handler._remap_lop_file_paths()
+
+        parm.set.assert_not_called()
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_handles_hscript_error(self, capfd):
+        """Prints error and continues when hscript pathmap fails."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, "/src/bad.usd")
+        self._setup_lop_nodes(parm)
+        hou.hscript.return_value = ("", "pathmap: error\n")
+
+        handler._remap_lop_file_paths()
+
+        parm.set.assert_not_called()
+        out, _ = capfd.readouterr()
+        assert "Error remapping" in out


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-houdini/issues/314
  
  ### What was the problem/requirement? (What/Why)
  
  `HOUDINI_PATHMAP` does not apply to USD/LOP node file path parameters (sublayer, reference, payload, etc.) because USD asset resolution
  uses ArResolver — not Houdini's native file I/O path mapping. This means when a scene with LOP sublayer or reference nodes using absolute
  paths is submitted to Deadline Cloud, the worker receives the submitting machine's local paths unchanged, causing render failure with
  `Unable to find layer file`.
  
  ### What was the solution? (How)
  
  Added `_remap_lop_file_paths()` in `houdini_handler.py` that runs after scene load (alongside the existing `_path_map_envs()`). It iterates
  all LOP nodes in the scene via `hou.node("/").recursiveGlob("*", filter=hou.nodeTypeFilter.Lop)` and applies `pathmap -t` to any string
  parameter that is either:
  - Tagged as `hou.stringParmType.FileReference` (e.g., sublayer's `filepath1`), or
  - Named `filepath*` (e.g., reference's `filepath1`, which SideFX inconsistently typed as `stringParmType.Regular`)
  
  Expression-based paths (`$HIP/...`, backtick expressions) are skipped to avoid clobbering variable references. Single quotes in paths are
  escaped to prevent hscript command injection.
  
  ### What is the impact of this change?
  
  LOP sublayer, reference, and other file-path-bearing LOP nodes will now have their paths correctly remapped on Deadline Cloud workers when
  `HOUDINI_PATHMAP` is configured via path mapping rules. No impact on non-LOP workflows — the method early-returns if `HOUDINI_PATHMAP` is
  not set.
  
  **Known limitation**: Absolute paths *inside* referenced USD files (e.g., composition arcs within a `.usd` file on disk) are not addressed
  by this fix — those would require a custom USD ArResolver plugin.
  
  ### How was this change tested?
  
  - Unit tests: 9 new tests in `TestRemapLopFilePaths` covering early return, successful remap (FileReference and filepath-named parms),
  empty values, expression skipping, non-string parm skipping, no-op on unchanged paths, and hscript error handling.
  - Integration tests: Submitted test scenes to Deadline Cloud using adaptor wheels with the fix. Verified on Houdini 19.5, 20.0, and 20.5 that
  sublayer/reference paths are remapped and renders complete successfully.
  
  #### Please run the integration tests and paste the results below.
  
  All 167 unit tests pass. Integration test confirmed render success on farm with path mapping rule
  `/Users/justins/dev/github/aws-deadline/deadline-cloud-for-houdini` → `/sessions/.../assetroot-...`. Adaptor output shows:
  
  Remapped LOP parm /stage/sublayer_mug/filepath1: /Users/justins/.../Mug.usda -> /sessions/.../Mug.usda
  Remapped LOP parm /stage/sublayer_chair/filepath1: /Users/justins/.../Chair.usda -> /sessions/.../Chair.usda
  
  #### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.
  
  N/A — no files added/removed, no installer changes.
  
  ### Was this change documented?
  
  - Docstring added to `_remap_lop_file_paths()` explaining why it exists (HOUDINI_PATHMAP/ArResolver gap) and what it does.
  - No README/schema changes needed — this is an internal adaptor behavior fix with no interface changes.
  
  ### Is this a breaking change?
  
  No. This is an additive fix that runs transparently during scene load. No changes to init-data, run-data, or the adaptor interface. Jobs
  submitted with older versions of the submitter will benefit from this fix on workers running the updated adaptor.
  
  ----
  
  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your
  choice.*