### PR TITLE
feat(telemetry): standardize exception_scope to 'caught'

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniAdaptor/adaptor.py
+++ b/src/deadline/houdini_adaptor/HoudiniAdaptor/adaptor.py
@@ -513,7 +513,8 @@ class HoudiniAdaptor(Adaptor[AdaptorConfiguration]):
             #  waiting for the next command. If the thread finished, then we cannot continue
             exit_code = self._houdini_client.returncode
             self._get_deadline_telemetry_client().record_error(
-                {"exit_code": exit_code, "exception_scope": "on_run"}, str(RuntimeError)
+                {"exit_code": exit_code, "exception_scope": "caught", "error_operation": "on_run"},
+                str(RuntimeError),
             )
             raise HoudiniNotRunningError(
                 "Houdini exited early and did not render successfully, please check render logs. "

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -716,7 +716,7 @@ def submit_callback(kwargs):
         )
     except Exception as exc:
         api.get_deadline_cloud_library_telemetry_client().record_error(
-            event_details={"exception_scope": "submit_callback"},
+            event_details={"exception_scope": "caught", "error_operation": "submit_callback"},
             exception_type=str(type(exc)),
             from_gui=True,
         )


### PR DESCRIPTION
Fixes: N/A (internal telemetry improvement)

### What was the problem/requirement? (What/Why)

The `exception_scope` field in telemetry error events was using lifecycle-specific values like `"on_run"`, `"on_submit"`, or `"submit_callback"` rather than standardized values. This makes it difficult to distinguish uncaught exceptions from handled errors in telemetry analysis, since the field describes *where* the error occurred rather than *how* it was caught.

### What was the solution? (How)

Standardized `exception_scope` to `"caught"` for all handled exceptions and preserved the previous lifecycle-specific value in a new `error_operation` field. This allows telemetry queries to cleanly filter by catch semantics (`"caught"` vs `"uncaught"`) while still providing drill-down capability by operation phase.

### What is the impact of this change?

No customer-facing impact. This is an internal telemetry change that improves the accuracy of error classification in our observability dashboards. The telemetry payload gains a new `error_operation` field and the `exception_scope` value changes from a lifecycle name to the standardized `"caught"`.

### How was this change tested?

- Verified the telemetry client's `record_error` method accepts the updated `event_details` dict structure
- Confirmed existing CloudWatch Logs Insights dashboard queries have been updated (in a separate change) to match both old and new event formats via OR clauses, ensuring no data gap during rollout

### Have you run a render job successfully with these changes?

No — this change only affects the metadata payload of telemetry events and does not alter render logic, submission behavior, or adaptor functionality.

### Was this change documented?

No documentation updates required. This is an internal telemetry field change with no impact on public APIs, CLI behavior, or adaptor schemas.

### Is this a breaking change?

No. The adaptor's init-data and run-data schemas are unchanged. The telemetry payload is internal and not part of the public contract.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*