### PR TITLE
feat: add headless HoudiniSubmitter on the unified BaseSubmitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.60.1,< 0.61",
+    "deadline >= 0.60.2,< 0.61",
     "openjd-adaptor-runtime >= 0.7,< 0.10",
 ]
 

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from dataclasses import dataclass
 from enum import Enum
 import copy
 import os
@@ -7,11 +8,12 @@ import sys
 import yaml
 import json
 import traceback
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from pathlib import Path
 
 from botocore.exceptions import ClientError
 
+from deadline.client.api import BaseSubmitter, BaseSubmitterSettings
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client import api
 from deadline.client.job_bundle.submission import AssetReferences
@@ -51,6 +53,258 @@ _REFRESHING_TEXT = "<refreshing>"
 class RenderStrategy(Enum):
     SEQUENTIAL = "SEQUENTIAL"
     PARALLEL = "PARALLEL"
+
+
+@dataclass
+class HoudiniSubmitterSettings(BaseSubmitterSettings):
+    """Houdini-specific submission settings for the unified :class:`BaseSubmitter`.
+
+    The Houdini submitter derives the job's step graph from the live ROP node
+    (via the module-level ``_get_job_template``). Beyond the DCC-agnostic base
+    fields (``job_name``, ``description``, ``priority``, ``initial_status``,
+    ``max_failed_tasks_count``, ``max_retries_per_task``, the asset-reference
+    lists) this carries the ROP node path plus the Houdini-specific
+    adaptor-wheels fields, so the build methods can honor consumer edits to
+    those values rather than silently re-reading the node.
+
+    Note: the *frame range* is intentionally not a settings-driven input. A
+    Houdini job's per-step frames/dependencies are derived from the live ROP
+    network via ``hscript render`` (see ``_get_rop_steps``); a single
+    ``frame_list`` string cannot represent that graph, so ``get_settings``
+    populates ``frame_list`` for information only and the builders take frames
+    from the ROP.
+    """
+
+    rop_node_path: str = ""
+    include_adaptor_wheels: bool = False
+    adaptor_wheels: str = ""
+
+
+class HoudiniSubmitter(BaseSubmitter):
+    """Headless :class:`BaseSubmitter` implementation for Houdini.
+
+    This is the unified-API entry point that host-agnostic consumers (e.g. the
+    AYON bridge, ``get_submitter_for_host("houdini")``) drive, and the same
+    engine the native GUI submitter routes through (see ``_create_job_bundle``).
+    ``get_job_template`` reuses the module-level ``_get_job_template`` for the
+    ROP-derived step graph and overrides the settings-driven fields; parameter
+    values are built from ``settings`` plus the ROP's queue parameters, and
+    asset references come from the ``_assets`` scene scan. The submitter
+    resolves everything from a single ROP node path; call
+    :meth:`set_rop_node_path` (or construct with one) before requesting
+    settings/templates.
+    """
+
+    def __init__(self, rop_node_path: str = "") -> None:
+        self._rop_node_path = rop_node_path
+
+    def set_rop_node_path(self, rop_node_path: str) -> None:
+        """Point the submitter at the Deadline Cloud ROP node to submit.
+
+        Lets external callers (e.g. the AYON create/publish plugins) seed the
+        node without reaching into the private attribute.
+        """
+        self._rop_node_path = rop_node_path
+
+    def _get_rop_node(self) -> Optional["hou.Node"]:
+        if self._rop_node_path:
+            return hou.node(self._rop_node_path)
+        return None
+
+    def _require_rop(self) -> "hou.Node":
+        rop = self._get_rop_node()
+        if rop is None:
+            raise RuntimeError(f"Cannot find ROP node at path: {self._rop_node_path}")
+        return rop
+
+    def get_settings(self, scan_assets: bool = True) -> HoudiniSubmitterSettings:
+        """Collect submission settings from the live scene / ROP node.
+
+        Populates the base-contract fields (job name, frame range, and the
+        input/output asset references discovered by walking the scene) so that
+        consumers reading them off the returned settings — e.g. the AYON create
+        plugin's parameterDefinitions UI and its publish-time job-attachments
+        collection — see real values rather than empty defaults. The scene scan
+        is the same one the native "Parse Files" button uses.
+
+        ``scan_assets`` (default ``True``, so base-contract callers are
+        unchanged) gates the input/output asset-reference scan. Callers that do
+        not read ``settings.input_*``/``output_directories`` — notably the GUI
+        submit/export path, which writes ``asset_references.yaml`` from the
+        dialog-provided references — can pass ``False`` to skip a potentially
+        expensive filesystem + USD walk whose output would be discarded.
+        """
+        settings = HoudiniSubmitterSettings()
+        hip_file = _get_hip_file()
+        settings.job_name = hou.hipFile.basename() or "Untitled"
+        settings.project_path = hou.getenv("HIP", "") or ""
+        # Baseline inputs: the hip file only. Overwritten below by the scene scan
+        # when it runs and succeeds; otherwise this fallback stands (no ROP, scan
+        # skipped, or scan failed).
+        settings.input_filenames = [hip_file] if hip_file else []
+
+        # frame_list from the playbar; refined from the ROP's frame-range tuple
+        # below when a node is available.
+        playbar = hou.playbar.frameRange()
+        settings.frame_list = f"{int(playbar[0])}-{int(playbar[1])}"
+        settings.output_path = settings.project_path
+
+        rop = self._get_rop_node()
+        if rop is not None:
+            settings.rop_node_path = rop.path()
+            if rop.parm("name"):
+                settings.job_name = rop.parm("name").evalAsString() or settings.job_name
+            if rop.parm("priority"):
+                settings.priority = rop.parm("priority").eval()
+            if rop.parm("initial_status"):
+                settings.initial_status = rop.parm("initial_status").evalAsString()
+            if rop.parm("failed_tasks_limit"):
+                settings.max_failed_tasks_count = rop.parm("failed_tasks_limit").eval()
+            if rop.parm("task_retry_limit"):
+                settings.max_retries_per_task = rop.parm("task_retry_limit").eval()
+            if rop.parm("description"):
+                settings.description = rop.parm("description").evalAsString()
+            if rop.parm("include_adaptor_wheels"):
+                settings.include_adaptor_wheels = bool(rop.parm("include_adaptor_wheels").eval())
+            if rop.parm("adaptor_wheels"):
+                settings.adaptor_wheels = rop.parm("adaptor_wheels").evalAsString()
+
+            frame_range = rop.parmTuple("f")
+            if frame_range:
+                start = int(frame_range[0].eval())
+                end = int(frame_range[1].eval())
+                step = int(frame_range[2].eval()) if len(frame_range) > 2 else 1
+                settings.frame_list = f"{start}-{end}:{step}" if step != 1 else f"{start}-{end}"
+
+            # Discover the real input/output asset references by scanning the
+            # scene (same detection as "Parse Files"), so consumers that read
+            # these off the settings get populated directories even when the
+            # ROP's Job Attachments multiparms have not been parsed yet. Skipped
+            # when scan_assets is False (the caller does not read these fields);
+            # on failure the hip-file baseline set above stands.
+            if scan_assets:
+                try:
+                    refs = _get_scene_asset_references(rop)
+                    settings.input_filenames = sorted(refs.input_filenames)
+                    settings.input_directories = sorted(refs.input_directories)
+                    settings.output_directories = sorted(refs.output_directories)
+                    if settings.output_directories:
+                        settings.output_path = settings.output_directories[0]
+                except Exception:
+                    # Scene scan can fail (e.g. missing/locked nodes); keep the
+                    # hip-file baseline rather than breaking settings collection.
+                    pass
+
+        return settings
+
+    def get_job_template(
+        self,
+        settings: BaseSubmitterSettings,
+        host_requirements: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        houdini_settings = cast(HoudiniSubmitterSettings, settings)
+        rop = self._require_rop()
+
+        # The step graph (per-step frames, dependencies, wedges) is derived from
+        # the live ROP network by _get_job_template and cannot be reconstructed
+        # from settings; the job name/description are settings-driven so a
+        # consumer's edits are honored (matching deadline-cloud-for-maya).
+        job_template = _get_job_template(rop, host_requirements)
+
+        if houdini_settings.job_name:
+            job_template["name"] = houdini_settings.job_name
+        if houdini_settings.description:
+            job_template["description"] = houdini_settings.description
+        elif "description" in job_template and not houdini_settings.description:
+            # An explicitly-cleared description should not fall back to the node.
+            del job_template["description"]
+
+        # Reconcile the adaptor-wheels override with settings so the template's
+        # AdaptorWheels parameterDefinition/jobEnvironment stays consistent with
+        # the AdaptorWheels *value* get_parameter_values emits (which is
+        # settings-driven). _get_job_template added the override based on the
+        # node; a headless consumer that edited the wheels settings could
+        # otherwise desync (definition without value, or value without
+        # definition -> CreateJob reject).
+        wheels_enabled = houdini_settings.include_adaptor_wheels and os.path.exists(
+            houdini_settings.adaptor_wheels
+        )
+        _apply_adaptor_wheels_override(job_template, wheels_enabled)
+
+        return job_template
+
+    def get_parameter_values(
+        self,
+        settings: BaseSubmitterSettings,
+        queue_parameters: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        houdini_settings = cast(HoudiniSubmitterSettings, settings)
+        rop = self._require_rop()
+
+        # Scalar job parameters come from settings (honoring consumer edits); the
+        # ROP is still consulted for its per-node queue parameter values and hip
+        # file, which have no settings equivalent.
+        parameter_values: list[dict[str, Any]] = [
+            {"name": "deadline:priority", "value": houdini_settings.priority},
+            {"name": "deadline:targetTaskRunStatus", "value": houdini_settings.initial_status},
+            {
+                "name": "deadline:maxFailedTasksCount",
+                "value": houdini_settings.max_failed_tasks_count,
+            },
+            {"name": "deadline:maxRetriesPerTask", "value": houdini_settings.max_retries_per_task},
+            {"name": "HipFile", "value": _get_hip_file()},
+            *get_queue_parameter_values_as_openjd(rop),
+        ]
+        if houdini_settings.include_adaptor_wheels and os.path.exists(
+            houdini_settings.adaptor_wheels
+        ):
+            parameter_values.append(
+                {"name": "AdaptorWheels", "value": houdini_settings.adaptor_wheels}
+            )
+
+        # Merge caller-supplied queue_parameters with caller-wins precedence.
+        # The node already emits its own queue parameters (CondaPackages,
+        # CondaChannels, ...) via get_queue_parameter_values_as_openjd, and a
+        # headless consumer (e.g. AYON) passes the SAME queue parameters here as
+        # its resolved/edited values -- so the two sets overlap by design. The
+        # caller's value supersedes the node's on a name collision (mirroring how
+        # the GUI's set_queue_parameter_values_from_openjd writes dialog edits
+        # back onto the node before the bundle is read). A plain de-dup also
+        # avoids the duplicate parameterValues that CreateJob rejects.
+        #
+        # An empty/None caller value is treated as "not provided": consumers such
+        # as AYON build this list from get_queue_parameters(), which resolves
+        # every parameter to its queue default -- and a queue whose CondaPackages
+        # default is empty would otherwise clobber the node's computed value
+        # (e.g. "houdini=20.5.* houdini-openjd=0.x.*"). We only let a caller value
+        # win when it actually carries a value, so a bare queue default never
+        # blanks a populated node parameter. Falsy-but-real values (0, False) are
+        # preserved.
+        caller_values = {
+            param["name"]: param["value"]
+            for param in queue_parameters
+            if "value" in param and param["value"] not in (None, "")
+        }
+        merged: list[dict[str, Any]] = [
+            {"name": param["name"], "value": caller_values.get(param["name"], param["value"])}
+            for param in parameter_values
+        ]
+        existing_names = {param["name"] for param in merged}
+        merged.extend(
+            {"name": name, "value": value}
+            for name, value in caller_values.items()
+            if name not in existing_names
+        )
+        return merged
+
+    def get_asset_references(self, settings: BaseSubmitterSettings) -> AssetReferences:
+        rop = self._require_rop()
+        # Scan the scene for the authoritative asset references rather than
+        # reading the ROP's (possibly unparsed) Job Attachments multiparms, so a
+        # headless consumer gets real input/output paths without a prior
+        # "Parse Files" pass. Returns the typed AssetReferences per the
+        # BaseSubmitter contract; callers serialize with .to_dict().
+        return _get_scene_asset_references(rop)
 
 
 def _get_houdini_version() -> str:
@@ -266,34 +520,12 @@ def _get_render_strategy_for_node(node: hou.Node) -> RenderStrategy:
     return render_strategy
 
 
-def _get_parameter_values(node: hou.Node) -> dict[str, Any]:
-    priority = node.parm("priority").eval()
-    initial_status = node.parm("initial_status").evalAsString()
-    failed_tasks_limit = node.parm("failed_tasks_limit").eval()
-    task_retry_limit = node.parm("task_retry_limit").eval()
-    parameter_values = [
-        {"name": "deadline:priority", "value": priority},
-        {"name": "deadline:targetTaskRunStatus", "value": initial_status},
-        {"name": "deadline:maxFailedTasksCount", "value": failed_tasks_limit},
-        {"name": "deadline:maxRetriesPerTask", "value": task_retry_limit},
-        {"name": "HipFile", "value": _get_hip_file()},
-        *get_queue_parameter_values_as_openjd(node),
-    ]
-
-    if node.parm("include_adaptor_wheels").eval():
-        parameter_values.append(
-            {"name": "AdaptorWheels", "value": node.parm("adaptor_wheels").evalAsString()}
-        )
-
-    return {"parameterValues": parameter_values}
-
-
 def read_ui_settings_from_node(node: hou.Node) -> HoudiniSubmitterUISettings:
     """Populate a HoudiniSubmitterUISettings from the Deadline Cloud ROP node's parameters.
 
     This lets the shared SubmitJobToDeadlineDialog (used by the Python panel) open with the
     node's configured values instead of pure dataclass defaults. Parameter names match those
-    defined in the HDA DialogScript and read elsewhere in this module (e.g. _get_parameter_values).
+    defined in the HDA DialogScript and read elsewhere in this module (e.g. get_settings).
 
     Note the deliberate name remapping: the node exposes ``failed_tasks_limit`` /
     ``task_retry_limit``, but deadline-cloud's SharedJobPropertiesWidget reads
@@ -474,6 +706,51 @@ def _get_job_template(
     return job_template
 
 
+def _load_adaptor_override_environment() -> dict[str, Any]:
+    override_file = os.path.join(os.path.dirname(__file__), "adaptor_override_environment.yaml")
+    with open(override_file) as yaml_file:
+        return yaml.safe_load(yaml_file)
+
+
+# Names contributed by adaptor_override_environment.yaml, used to detect/strip
+# the override so the template can be reconciled with the settings-driven state.
+_ADAPTOR_OVERRIDE_PARAM_NAMES = {"AdaptorWheels", "OverrideAdaptorName"}
+_ADAPTOR_OVERRIDE_ENV_NAME = "OverrideAdaptor"
+
+
+def _apply_adaptor_wheels_override(job_template: dict[str, Any], enabled: bool) -> None:
+    """Add or remove the adaptor-wheels override on ``job_template`` in place.
+
+    Idempotent: makes the AdaptorWheels ``parameterDefinition``s and the
+    ``OverrideAdaptor`` ``jobEnvironment`` present when ``enabled`` and absent
+    otherwise, regardless of what the node-driven ``_get_job_template`` already
+    added. This keeps the template consistent with the settings-driven
+    AdaptorWheels parameter *value* emitted by ``get_parameter_values``.
+    """
+    already_present = any(
+        pd.get("name") in _ADAPTOR_OVERRIDE_PARAM_NAMES
+        for pd in job_template.get("parameterDefinitions", [])
+    )
+
+    if enabled and not already_present:
+        override = _load_adaptor_override_environment()
+        job_template.setdefault("parameterDefinitions", []).extend(override["parameterDefinitions"])
+        job_template.setdefault("jobEnvironments", []).append(override["environment"])
+    elif not enabled and already_present:
+        job_template["parameterDefinitions"] = [
+            pd
+            for pd in job_template.get("parameterDefinitions", [])
+            if pd.get("name") not in _ADAPTOR_OVERRIDE_PARAM_NAMES
+        ]
+        job_template["jobEnvironments"] = [
+            env
+            for env in job_template.get("jobEnvironments", [])
+            if env.get("name") != _ADAPTOR_OVERRIDE_ENV_NAME
+        ]
+        if not job_template["jobEnvironments"]:
+            del job_template["jobEnvironments"]
+
+
 def _get_step_template(node: Dict, ignore_input_nodes: bool):
     init_data = {
         "scene_file": "{{Param.HipFile}}",
@@ -567,13 +844,25 @@ def _create_job_bundle(
     asset_references: AssetReferences,
     host_requirements: Optional[Dict[str, Any]] = None,
 ) -> None:
+    # Drive the unified HoudiniSubmitter engine so the GUI submit/export path
+    # and headless consumers (e.g. AYON) build the template + parameter values
+    # through one implementation. Pass the submitter's own get_settings() (read
+    # from this ROP) so the settings-driven builders see the node's real values;
+    # the produced bundle matches what the node configures.
+    # The dialog-provided asset_references are written as-is (they carry the
+    # user's Job Attachments edits) rather than re-scanned, so scan_assets=False
+    # skips get_settings()'s scene/USD asset walk whose output this path would
+    # only discard (the dialog already scanned the scene once when it opened).
+    submitter = HoudiniSubmitter(rop_node.path())
+    settings = submitter.get_settings(scan_assets=False)
+    job_template = submitter.get_job_template(settings, host_requirements)
+    parameter_values = submitter.get_parameter_values(settings, [])
+
     job_bundle_path = Path(job_bundle_dir)
-    job_template = _get_job_template(rop_node, host_requirements)
-    parameter_values = _get_parameter_values(rop_node)
     with open(job_bundle_path / "template.yaml", "w", encoding="utf8") as f:
         deadline_yaml_dump(job_template, f, indent=1)
     with open(job_bundle_path / "parameter_values.yaml", "w", encoding="utf8") as f:
-        deadline_yaml_dump(parameter_values, f, indent=1)
+        deadline_yaml_dump({"parameterValues": parameter_values}, f, indent=1)
     with open(job_bundle_path / "asset_references.yaml", "w", encoding="utf8") as f:
         deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
 

--- a/test/unit/deadline_submitter_for_houdini/test_houdini_submitter.py
+++ b/test/unit/deadline_submitter_for_houdini/test_houdini_submitter.py
@@ -1,0 +1,307 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for the headless HoudiniSubmitter(BaseSubmitter) engine.
+
+The unified base class (BaseSubmitter) lives in deadline-cloud and is
+re-exported from ``deadline.client.api``. These tests import the submitter
+module directly (which imports BaseSubmitter at load); they fail until a
+deadline release carrying the base is installed and pass once it is.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from deadline.client.job_bundle.submission import AssetReferences
+
+from deadline.houdini_submitter.python.deadline_cloud_for_houdini import submitter
+
+
+def _parm(value):
+    p = mock.MagicMock()
+    p.eval.return_value = value
+    p.evalAsString.return_value = str(value)
+    return p
+
+
+def _make_rop(frame_tuple=(1, 100, 1)):
+    rop = mock.MagicMock()
+    rop.path.return_value = "/out/deadline_cloud1"
+    parms = {
+        "name": _parm("mantra_job"),
+        "priority": _parm(50),
+        "initial_status": _parm("READY"),
+        "failed_tasks_limit": _parm(20),
+        "task_retry_limit": _parm(5),
+        "description": _parm("my rop"),
+    }
+    rop.parm.side_effect = lambda n: parms.get(n)
+    ftuple = [_parm(frame_tuple[0]), _parm(frame_tuple[1]), _parm(frame_tuple[2])]
+    rop.parmTuple.side_effect = lambda n: ftuple if n == "f" else None
+    return rop
+
+
+def test_engine_is_concrete_base_submitter():
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    assert isinstance(api, submitter.BaseSubmitter)
+
+
+def test_set_rop_node_path_updates_resolved_node():
+    api = submitter.HoudiniSubmitter()
+    assert api._get_rop_node() is None
+    api.set_rop_node_path("/out/deadline_cloud1")
+    with mock.patch.object(submitter, "hou") as hou_mock:
+        api._get_rop_node()
+    hou_mock.node.assert_called_once_with("/out/deadline_cloud1")
+
+
+def test_get_settings_populates_frame_list_and_scene_refs():
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    refs = AssetReferences(
+        input_filenames={"/scene.hip"},
+        input_directories={"/proj/geo"},
+        output_directories={"/proj/render"},
+    )
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_hip_file", return_value="/scene.hip"),
+        mock.patch.object(submitter, "_get_scene_asset_references", return_value=refs),
+    ):
+        hou_mock.hipFile.basename.return_value = "scene.hip"
+        hou_mock.getenv.return_value = "/proj"
+        hou_mock.playbar.frameRange.return_value = (1.0, 10.0)
+        hou_mock.node.return_value = _make_rop((1, 100, 3))
+        settings = api.get_settings()
+
+    # ROP frame-range tuple wins over the playbar and preserves the step.
+    assert settings.frame_list == "1-100:3"
+    assert settings.job_name == "mantra_job"
+    # Scene-scanned references flow into the ABC fields (so AYON's publish
+    # collector, which reads settings.*, gets real dirs).
+    assert settings.input_directories == ["/proj/geo"]
+    assert settings.output_directories == ["/proj/render"]
+    assert settings.output_path == "/proj/render"
+
+
+def test_get_settings_scan_assets_false_skips_scene_scan():
+    # The GUI submit/export path writes asset_references.yaml from the
+    # dialog-provided references and never reads settings.input_*/output_*, so it
+    # passes scan_assets=False to skip the (potentially expensive) scene + USD
+    # walk. Scalars/frame range are still populated; the asset scan is not run.
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_hip_file", return_value="/scene.hip"),
+        mock.patch.object(submitter, "_get_scene_asset_references") as scan,
+    ):
+        hou_mock.hipFile.basename.return_value = "scene.hip"
+        hou_mock.getenv.return_value = "/proj"
+        hou_mock.playbar.frameRange.return_value = (1.0, 10.0)
+        hou_mock.node.return_value = _make_rop((1, 100, 3))
+        settings = api.get_settings(scan_assets=False)
+
+    # The expensive scene/USD scan was not performed...
+    scan.assert_not_called()
+    # ...but scalar + frame-range settings are still collected from the ROP.
+    assert settings.frame_list == "1-100:3"
+    assert settings.job_name == "mantra_job"
+    # No scanned refs; falls back to the hip file only.
+    assert settings.input_filenames == ["/scene.hip"]
+    assert settings.input_directories == []
+    assert settings.output_directories == []
+
+
+def test_get_job_template_delegates_to_node_builder_and_overrides_from_settings():
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    rop = _make_rop()
+    # The node builder returns the ROP-derived template (step graph, node name);
+    # the engine then overrides settings-driven fields.
+    node_template = {
+        "specificationVersion": "jobtemplate-2023-09",
+        "name": "node_name",
+        "steps": [],
+    }
+    settings = submitter.HoudiniSubmitterSettings(job_name="Edited Job", description="Edited desc")
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_job_template", return_value=node_template) as build,
+    ):
+        hou_mock.node.return_value = rop
+        result = api.get_job_template(settings, {"amounts": []})
+    # step graph still comes from the node builder (host_requirements forwarded)...
+    build.assert_called_once_with(rop, {"amounts": []})
+    # ...but the settings-driven scalars win.
+    assert result["name"] == "Edited Job"
+    assert result["description"] == "Edited desc"
+
+
+def test_get_parameter_values_settings_driven_and_merges_queue_params():
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    settings = submitter.HoudiniSubmitterSettings(
+        priority=99, initial_status="SUSPENDED", max_failed_tasks_count=7, max_retries_per_task=2
+    )
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_hip_file", return_value="/scene.hip"),
+        mock.patch.object(submitter, "get_queue_parameter_values_as_openjd", return_value=[]),
+    ):
+        hou_mock.node.return_value = _make_rop()
+        result = api.get_parameter_values(
+            settings,
+            [{"name": "deadline:maxWorkerCount", "value": 3}],  # disjoint -> appended
+        )
+    by_name = {p["name"]: p["value"] for p in result}
+    # scalar deadline:* values come from settings, not the node
+    assert by_name["deadline:priority"] == 99
+    assert by_name["deadline:targetTaskRunStatus"] == "SUSPENDED"
+    assert by_name["deadline:maxFailedTasksCount"] == 7
+    assert by_name["deadline:maxRetriesPerTask"] == 2
+    # disjoint caller queue parameter is appended
+    assert by_name["deadline:maxWorkerCount"] == 3
+
+
+def test_get_parameter_values_queue_params_caller_wins_on_collision():
+    # Realistic headless flow: the node emits its own CondaPackages via
+    # get_queue_parameter_values_as_openjd, and the caller (e.g. AYON) passes the
+    # SAME queue parameter as its resolved value. The caller's value must win
+    # (de-dup, no duplicate parameterValues, no error).
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_hip_file", return_value="/scene.hip"),
+        mock.patch.object(
+            submitter,
+            "get_queue_parameter_values_as_openjd",
+            return_value=[
+                {"name": "CondaPackages", "value": "houdini"},  # node's value
+                {"name": "CondaChannels", "value": "deadline-cloud"},
+            ],
+        ),
+    ):
+        hou_mock.node.return_value = _make_rop()
+        result = api.get_parameter_values(
+            settings=submitter.HoudiniSubmitterSettings(),
+            queue_parameters=[
+                {"name": "CondaPackages", "value": "houdini py311"},  # caller override
+                {"name": "deadline:maxWorkerCount", "value": 3},  # disjoint -> appended
+            ],
+        )
+    names = [p["name"] for p in result]
+    by_name = {p["name"]: p["value"] for p in result}
+    # caller's value supersedes the node's, exactly once (no duplicate)
+    assert names.count("CondaPackages") == 1
+    assert by_name["CondaPackages"] == "houdini py311"
+    # node-only queue param preserved; disjoint caller param appended
+    assert by_name["CondaChannels"] == "deadline-cloud"
+    assert by_name["deadline:maxWorkerCount"] == 3
+
+
+def test_get_parameter_values_empty_caller_value_does_not_clobber_node():
+    # Regression: AYON's create path builds queue_parameters from
+    # get_queue_parameters(), which resolves EVERY parameter to its queue
+    # default -- including a CondaPackages whose queue default is empty. That
+    # empty value must NOT override the node's computed CondaPackages (e.g.
+    # "houdini=20.5.* houdini-openjd=0.x.*"); an empty/None caller value is
+    # treated as "not provided" so caller-wins only applies to real overrides.
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_hip_file", return_value="/scene.hip"),
+        mock.patch.object(
+            submitter,
+            "get_queue_parameter_values_as_openjd",
+            return_value=[
+                # node's computed value, populated by update_queue_parameters
+                {"name": "CondaPackages", "value": "houdini=20.5.* houdini-openjd=0.48.*"},
+            ],
+        ),
+    ):
+        hou_mock.node.return_value = _make_rop()
+        result = api.get_parameter_values(
+            settings=submitter.HoudiniSubmitterSettings(),
+            queue_parameters=[
+                {"name": "CondaPackages", "value": ""},  # empty queue default
+                {"name": "CondaChannels", "value": None},  # unset -> ignored
+            ],
+        )
+    by_name = {p["name"]: p["value"] for p in result}
+    names = [p["name"] for p in result]
+    # node's computed value survives; empty caller default did not clobber it
+    assert by_name["CondaPackages"] == "houdini=20.5.* houdini-openjd=0.48.*"
+    assert names.count("CondaPackages") == 1
+    # an empty/None caller-only parameter is not emitted as a blank value
+    assert "CondaChannels" not in by_name
+
+
+def test_get_job_template_adaptor_wheels_consistent_with_settings(tmp_path):
+    # Template's AdaptorWheels definition/env must track the settings-driven
+    # value in get_parameter_values, not the node. Node builder returns a
+    # template WITHOUT the override; settings enable it (existing path) -> the
+    # engine adds the AdaptorWheels definition + OverrideAdaptor jobEnvironment.
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    wheels_dir = str(tmp_path)  # exists, so wheels are "enabled"
+    settings = submitter.HoudiniSubmitterSettings(
+        include_adaptor_wheels=True, adaptor_wheels=wheels_dir
+    )
+    node_template = {
+        "specificationVersion": "jobtemplate-2023-09",
+        "name": "n",
+        "parameterDefinitions": [{"name": "HipFile"}],
+        "steps": [],
+    }
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_job_template", return_value=node_template),
+    ):
+        hou_mock.node.return_value = _make_rop()
+        tmpl = api.get_job_template(settings)
+    def_names = {pd["name"] for pd in tmpl["parameterDefinitions"]}
+    env_names = {env["name"] for env in tmpl.get("jobEnvironments", [])}
+    assert "AdaptorWheels" in def_names
+    assert "OverrideAdaptor" in env_names
+
+
+def test_get_job_template_strips_adaptor_wheels_when_settings_disable():
+    # Node builder returns a template WITH the override, but settings disable
+    # wheels -> the engine strips the definition/env so the template carries no
+    # AdaptorWheels definition without a value.
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    settings = submitter.HoudiniSubmitterSettings(include_adaptor_wheels=False)
+    node_template = {
+        "specificationVersion": "jobtemplate-2023-09",
+        "name": "n",
+        "parameterDefinitions": [{"name": "HipFile"}, {"name": "AdaptorWheels"}],
+        "jobEnvironments": [{"name": "OverrideAdaptor"}],
+        "steps": [],
+    }
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_job_template", return_value=node_template),
+    ):
+        hou_mock.node.return_value = _make_rop()
+        tmpl = api.get_job_template(settings)
+    def_names = {pd["name"] for pd in tmpl["parameterDefinitions"]}
+    assert "AdaptorWheels" not in def_names
+    assert "jobEnvironments" not in tmpl  # only entry removed -> key dropped
+
+
+def test_get_asset_references_returns_typed_scene_scan():
+    api = submitter.HoudiniSubmitter("/out/deadline_cloud1")
+    refs = AssetReferences(input_filenames={"/scene.hip"})
+    with (
+        mock.patch.object(submitter, "hou") as hou_mock,
+        mock.patch.object(submitter, "_get_scene_asset_references", return_value=refs) as scan,
+    ):
+        hou_mock.node.return_value = _make_rop()
+        result = api.get_asset_references(submitter.HoudiniSubmitterSettings())
+    assert result is refs
+    assert isinstance(result, AssetReferences)
+    scan.assert_called_once()
+
+
+def test_missing_rop_raises_runtimeerror():
+    api = submitter.HoudiniSubmitter()  # no path -> _get_rop_node returns None
+    with pytest.raises(RuntimeError, match="Cannot find ROP node"):
+        api.get_job_template(submitter.HoudiniSubmitterSettings())


### PR DESCRIPTION
Fixes: N/A (no tracking issue; enables the AYON Houdini integration on the unified submitter API)

### What was the problem/requirement? (What/Why)

Host-agnostic consumers — notably the AYON bridge, which resolves submitters via `get_submitter_for_host("houdini")` — need to drive Houdini submission headlessly, with no GUI. That requires a Houdini implementation of the unified `BaseSubmitter` ABC (`deadline.client.api`, aws-deadline/deadline-cloud#1245): `get_settings` / `get_job_template` / `get_parameter_values` / `get_asset_references`.

The Houdini submitter had no such engine. It was also just re-migrated to the shared Qt dialog in #372, so a naive second implementation would duplicate the node-driven bundle builders and risk the GUI and headless paths drifting apart.

### What was the solution? (How)

Add a headless `HoudiniSubmitter(BaseSubmitter)` + `HoudiniSubmitterSettings(BaseSubmitterSettings)` in `submitter.py`, layered on top of #372 as a thin adapter over its existing node-driven builders, and route the GUI's own bundle path through the same engine — so both paths share one implementation and emit identical bundles.

- **`deadline_cloud_for_houdini/submitter.py`**
  - New `HoudiniSubmitter(BaseSubmitter)` + `HoudiniSubmitterSettings(BaseSubmitterSettings)`. The submitter resolves everything from a single ROP node path (`set_rop_node_path()` / constructor arg).
  - `get_settings` scans the scene for the real input/output asset references (same detection as "Parse Files") so consumers reading `settings.*` (e.g. AYON's create parameterDefinitions UI and its publish-time job-attachments collection) get populated directories rather than empty defaults. It takes a `scan_assets: bool = True` flag; the GUI submit/export path passes `False` to skip the scene/USD walk it would only discard.
  - `get_job_template` delegates to the node-driven `_get_job_template` for the ROP-derived step graph and overrides the settings-driven scalars (job name/description); it also reconciles the `AdaptorWheels` parameterDefinition + `OverrideAdaptor` jobEnvironment with the settings-driven value so the template and parameter values stay consistent.
  - `get_parameter_values` sources scalar `deadline:*` values from settings and merges caller-supplied `queue_parameters` with **caller-wins** precedence, de-duping the ROP's own values. An empty/`None` caller value is treated as "not provided", so a bare queue default never blanks a populated node parameter (e.g. the computed `CondaPackages`).
  - `get_asset_references` returns the typed `AssetReferences` per the base contract.
  - `_create_job_bundle` (the GUI submit/export callback path from #372) now builds the template + parameter values by driving `HoudiniSubmitter` instead of calling the module builders directly. The dialog-provided `asset_references` are still written as-is (they carry the user's Job Attachments edits).
- **`pyproject.toml`**: pin `deadline >= 0.60.2, < 0.61` — `0.60.2` is the first release carrying `BaseSubmitter` (`0.60.1` has none).

### What is the impact of this change?

- AYON (and any other host-agnostic consumer) can drive Houdini submission headlessly through the unified `BaseSubmitter` API.
- The native Houdini GUI submit/export path and the headless path now share a single bundle-building implementation, so there is one source of truth for bundle contents (no GUI/headless drift).
- Additive only — no change to the #372 GUI behavior; the GUI bundle output is byte-identical before/after routing through the engine.

### How was this change tested?

**Unit** — Full submitter unit suite passes against `deadline 0.60.2`, including the new engine tests in `test/unit/.../test_houdini_submitter.py` (ABC conformance, `set_rop_node_path`, `get_settings` frame-range + scene-ref population, `scan_assets=False` skip, builder delegation, settings-driven overrides, queue-param caller-wins merge incl. the empty-caller-value regression, adaptor-wheels consistency, missing-ROP error). `ruff` / `black` / `mypy` clean. Verified the GUI bundle output is byte-identical before/after routing through `HoudiniSubmitter`.

#### Please run the integration tests and paste the results below.

Ran the repo's submitter integration suite (`test/integ`, `-m submitter`) against Houdini **21.0.631** (hython), per `.kiro/powers/houdini-dev-power/steering/integration-testing.md`. These tests launch hython with each test scene, build a job bundle via the routed `HoudiniSubmitter` path, validate the template with `openjd check`, and compare against the expected bundle. Run logged out of Deadline Cloud (isolated empty config) so live queue parameters don't leak into the generated templates.

```
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter        PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter            PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter   PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_usd_scene_dependency_detection  PASSED
============================== 4 passed in 9.02s ==============================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

N/A — `installer/` was not modified, and no file was added or removed from `src/` (only `src/.../submitter.py` was modified in place; the new file is a unit test under `test/`).

### Was this change documented?

Yes — docstrings were added/updated for `HoudiniSubmitter`, `HoudiniSubmitterSettings`, and all four base-contract methods (including the `scan_assets` flag on `get_settings`). No README/DEVELOPMENT/adaptor-schema changes are needed: this change is submitter-only and does not touch the adaptor's init-data/run-data.

### Is this a breaking change?

No. The change is additive — a new headless engine plus internal routing of the existing GUI bundle path through it. No public adaptor init-data/run-data contract is changed, and the GUI submit/export output is byte-identical. The only dependency change is raising the `deadline` floor to `>= 0.60.2` (first release carrying `BaseSubmitter`).

## Depends on
aws-deadline/deadline-cloud#1245 (the `BaseSubmitter` / `BaseSubmitterSettings` base contract, re-exported from `deadline.client.api`), released in `deadline` `0.60.2`.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
