### PR TITLE
fix: lazy-import deadline-cloud Qt UI to prevent Python segfault in integ tests

### DIFF
--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -18,8 +18,6 @@ from deadline.client.job_bundle import create_job_history_bundle_dir
 from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.config import get_setting
 from deadline.client.config.config_file import str2bool
-from deadline.client.ui.dialogs.submit_job_progress_dialog import SubmitJobProgressDialog
-from deadline.client.ui.dialogs import DeadlineConfigDialog, DeadlineLoginDialog
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentS3Settings
 
@@ -719,6 +717,10 @@ def submit_callback(kwargs):
             from_gui=True,
         )
 
+        # Imported lazily so merely importing this module (e.g. the headless job-bundle path
+        # exercised by integ tests in hython) does not pull in deadline-cloud's Qt/PySide UI.
+        from deadline.client.ui.dialogs.submit_job_progress_dialog import SubmitJobProgressDialog
+
         job_progress_dialog = SubmitJobProgressDialog(parent=hou.qt.mainWindow())
         job_progress_dialog.start_submission(
             farm_id,
@@ -748,6 +750,9 @@ def submit_callback(kwargs):
 def settings_callback(kwargs):
     node = kwargs["node"]
     _show_farm_and_queue_as_refreshing(node)
+    # Lazy import: keep deadline-cloud's Qt/PySide UI out of the module-import path (see submit_callback).
+    from deadline.client.ui.dialogs import DeadlineConfigDialog
+
     DeadlineConfigDialog.configure_settings(parent=hou.qt.mainWindow())
     try:
         _apply_farm_and_queue_settings(node)
@@ -763,6 +768,9 @@ def settings_callback(kwargs):
 def login_callback(kwargs):
     node = kwargs["node"]
     _show_farm_and_queue_as_refreshing(node)
+    # Lazy import: keep deadline-cloud's Qt/PySide UI out of the module-import path (see submit_callback).
+    from deadline.client.ui.dialogs import DeadlineLoginDialog
+
     DeadlineLoginDialog.login(parent=hou.qt.mainWindow())
     try:
         _apply_farm_and_queue_settings(node)

--- a/test/unit/deadline_submitter_for_houdini/test_login_callback.py
+++ b/test/unit/deadline_submitter_for_houdini/test_login_callback.py
@@ -10,9 +10,9 @@ from deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter impo
 
 @pytest.fixture(scope="function", autouse=True)
 def mock_login_dialog():
-    with mock.patch(
-        "deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter.DeadlineLoginDialog"
-    ) as login_dialog:
+    # login_callback imports DeadlineLoginDialog lazily, so patch it at its source module
+    # (the name is resolved from deadline.client.ui.dialogs at call time, not on the submitter module).
+    with mock.patch("deadline.client.ui.dialogs.DeadlineLoginDialog") as login_dialog:
         yield login_dialog
 
 

--- a/test/unit/deadline_submitter_for_houdini/test_settings_callback.py
+++ b/test/unit/deadline_submitter_for_houdini/test_settings_callback.py
@@ -10,9 +10,9 @@ from deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter impo
 
 @pytest.fixture(scope="function", autouse=True)
 def mock_config_dialog():
-    with mock.patch(
-        "deadline.houdini_submitter.python.deadline_cloud_for_houdini.submitter.DeadlineConfigDialog"
-    ) as config_dialog:
+    # settings_callback imports DeadlineConfigDialog lazily, so patch it at its source module
+    # (the name is resolved from deadline.client.ui.dialogs at call time, not on the submitter module).
+    with mock.patch("deadline.client.ui.dialogs.DeadlineConfigDialog") as config_dialog:
         yield config_dialog
 
 


### PR DESCRIPTION
## What

Move the three deadline-cloud UI dialog imports (`SubmitJobProgressDialog`, `DeadlineConfigDialog`, `DeadlineLoginDialog`) in `submitter.py` from module scope into the GUI callbacks that actually use them, so importing the module no longer loads Qt/PySide.

## Why

The mainline Houdini integration tests started failing on **Linux only** after #364 merged ([run 29355394297](https://github.com/aws-deadline/deadline-cloud-for-houdini/actions/runs/29355394297)). `test_usd_scene_dependency_detection` exited with code **139 (SIGSEGV)** while Windows and macOS passed on the identical commit.

The crash is **not** in USD dependency detection — the failing assertion is just the `output.returncode == 0` guard. The hython subprocess segfaulted at interpreter shutdown:

```
QSocketNotifier: Can only be used with threads started with QThread
Fatal error: Segmentation fault
  ...
  Shiboken::AutoDecRef::~AutoDecRef()  <QtCore.cpython-39>
  QRunnableWrapper::run() / QThreadPool::cancel(...)   <libQt5Core.so.5>
  ...
  PyGC_Collect / Py_FinalizeEx / Py_RunMain
```

The submitter integ tests drive the headless `_create_job_bundle` path, which does not need any Qt UI. But `submitter.py` imported `deadline.client.ui.dialogs` at module scope, so merely importing the module pulled Qt/PySide into hython. After the `deadline` floor moved to `0.60.1` (which ships a `QThreadPool`-based async layer plus a non-Qt telemetry thread), that created a shutdown-time thread/GC teardown race — a Qt object destroyed on a `QThreadPool` worker during `Py_FinalizeEx`. Timing-sensitive, hence Linux-only and load-sensitive (the USD test loads the heaviest scene).

## Fix

Lazy-import the dialogs inside the callbacks. The headless import path never loads Qt, which fully removes the crash surface (verified no other top-level import of this module pulls in Qt). The GUI callbacks import the dialogs on first use — when Qt is needed anyway.

The two callback unit tests are repointed to patch the dialogs at their source module (`deadline.client.ui.dialogs`) since they are no longer attributes of the submitter module.

## Testing

- Full submitter unit suite passes (89 tests), including the two edited callback tests.
- Could not reproduce the segfault locally (no hython available), so the definitive confirmation is a green Linux integration run on this PR.