### PR TITLE
chore(dependabot): group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,25 @@ updates:
       interval: "daily"
     commit-message: 
       prefix: "chore(deps):"
+    # Combine all minor and patch bumps into a single PR. Major bumps do not
+    # match this group and so each get their own individual PR.
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    # Combine all minor and patch bumps into a single PR. Major bumps do not
+    # match this group and so each get their own individual PR.
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Dependabot opens a lot of individual PRs for minor and patch version bumps. Each one has to be reviewed and rebase-merged on its own, which is a lot of churn for routine updates.

### What was the solution? (How)

Use Dependabot [`groups`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) in `.github/dependabot.yml` to combine all minor and patch updates into a single PR per ecosystem (`pip` and `github-actions`). Major version bumps do not match the group and continue to get individual PRs.

See also [Example 3: Individual pull requests for major updates and grouped for minor/patch updates](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates).

This mirrors OpenJobDescription/openjd-rs#273; the resulting effect can be seen in OpenJobDescription/openjd-rs#275.

### What is the impact of this change?

Fewer Dependabot PRs and a better update experience.

### How was this change tested?

Config-only change to `.github/dependabot.yml`, validated as well-formed YAML. The same approach is already in effect in openjd-rs (OpenJobDescription/openjd-rs#275).

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/mainline/DEVELOPMENT.md) for information on running tests.

- Have you run the unit tests? N/A (no code change)

#### Please run the integration tests and paste the results below.

N/A (no code change)

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

N/A (no code change)

### Was this change documented?

N/A (config-only change).

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
