### PR TITLE
feat: add support for Houdini 22.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -150,7 +150,8 @@ To run integration tests:
    ```powershell
    # Python version should be 3.9 for Houdini 19.5,
    # 3.10 for Houdini 20.0,
-   # and 3.11 for Houdini 20.5 & 21.0.
+   # 3.11 for Houdini 20.5 & 21.0,
+   # and 3.13 for Houdini 22.0.
    pip install -r requirements-integ-dcc-env.txt --python-version=3.11 --only-binary=:all: --target="C:\\Program Files\\Side Effects Software\\Houdini 20.5.487\\python311\\lib\\site-packages"
    ```
 1. Run `hatch run integ:test`. **If you are on Windows**, you may need Admin privileges to run the tests.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ability to run Houdini efficiently on your render farm.
 
 This library requires:
 
-1. Houdini 19.5, 20.0, 20.5 or 21.0
+1. Houdini 19.5, 20.0, 20.5, 21.0 or 22.0
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -48,7 +48,7 @@ pre-install-commands = [
 ]
 
 [[envs.integ-ci.matrix]]
-houdini = ["19.5.805", "20.0.896", "20.5.613", "21.0.440"]
+houdini = ["19.5.805", "20.0.896", "20.5.613", "21.0.440", "22.0.368"]
 
 [envs.integ-ci.env-vars]
 HOUDINI_VERSION = "{matrix:houdini}"

--- a/install_builder/deadline-cloud-for-houdini.xml
+++ b/install_builder/deadline-cloud-for-houdini.xml
@@ -2,7 +2,7 @@
 <componentGroup>
     <name>deadline_cloud_for_houdini</name>
     <description>Deadline Cloud for Houdini</description>
-    <detailedDescription>Houdini plugin for submitting jobs to AWS Deadline Cloud. Compatible with Houdini 19.5-21.0</detailedDescription>
+    <detailedDescription>Houdini plugin for submitting jobs to AWS Deadline Cloud. Compatible with Houdini 19.5-22.0</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -388,6 +388,83 @@
                 </if>
             </postInstallationActionList>
         </component>
+         <component>
+            <name>houdini_22_0</name>
+            <description>Houdini 22.0</description>
+            <selected>0</selected>
+            <parameterList>
+                <directoryParameter>
+                    <name>houdini_22_0_packagedir</name>
+                    <description>Houdini 22.0 Packages Directory</description>
+                    <explanation>Enter the path to the Houdini 22.0 packages directory. For easiest installation, Houdini should be installed before installing Deadline Cloud for Houdini.</explanation>
+                    <allowEmptyValue>0</allowEmptyValue>
+                    <ask>yes</ask>
+                    <cliOptionName>houdini-22-0-package-dir</cliOptionName>
+                    <cliOptionText>Path to the Houdini 22.0 packages directory. When the installer is run, if the HOUDINI_USER_PREF_DIR environment variable is set, this directory will default to the packages subdirectory at that path.</cliOptionText>
+                    <mustBeWritable>yes</mustBeWritable>
+                    <!-- Do not show this parameter on Windows; we will just add the installation directory to HOUDINI_PACKAGE_DIR. -->
+                    <ruleList>
+                        <platformTest type="windows" negate="true"/>
+                    </ruleList>
+                    <!-- For non-Windows, choose an appropriate default based on install scope and OS -->
+                    <preShowPageActionList>
+                        <!-- User (any): Set based on user pref -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_22_0_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <setInstallerVariable name="houdini_22_0_packagedir" value="${houdini_user_pref_dir_default}22.0/packages"/>
+                            </actionList>
+                        </if>
+
+                        <!-- System (any): Set based on default Houdini location for the OS -->
+                        <if>
+                            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${houdini_22_0_packagedir}" value=""/>
+                                <compareText logic="equals" text="${installscope}" value="system"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="linux" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_22_0_packagedir" value="/opt/hfs22.0/packages" />
+                                    </actionList>
+                                </if>
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx" />   
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable name="houdini_22_0_packagedir" value="/Applications/Houdini/Current/Frameworks/Houdini.framework/Versions/Current/Resources/packages"/>
+                                    </actionList>
+                                </if>
+                            </actionList>
+                        </if>
+                    </preShowPageActionList>
+                </directoryParameter>
+            </parameterList>
+            <postInstallationActionList>
+                <!-- On Windows, we don't require copying the package file and can just set an environment variable.
+                For macOS and Linux, we must copy the file into the latest Houdini installation. -->
+                <if>
+                    <conditionRuleList>
+                        <platformTest type="windows"/>
+                    </conditionRuleList>
+                    <actionList>
+                        <fnAddPathEnvironmentVariable name="HOUDINI_PACKAGE_DIR" value="${houdini_packagedir}" scope="${installscope}"/>
+                    </actionList>
+                    <elseActionList>
+                        <fnCopyHoudiniPackageFile destinationDir="${houdini_22_0_packagedir}" />
+                    </elseActionList>
+                </if>
+            </postInstallationActionList>
+        </component>
     </componentList>
     <preInitializationActionList>
         <if>
@@ -449,8 +526,8 @@
     </readyToInstallActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_houdini_summary" ask="0" cliOptionShow="0">
-            <value>Deadline Cloud for Houdini 19.5-21.0
-- Compatible with Houdini 19.5-21.0
+            <value>Deadline Cloud for Houdini 19.5-22.0
+- Compatible with Houdini 19.5-22.0
 - Install the integrated Houdini submitter files to the installation directory.
 - Copy the plug-in package file to the Houdini packages directory for each version.
 - Register the plug-in package file with Houdini by setting HOUDINI_PACKAGE_DIR on Windows.</value>

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -40,6 +40,12 @@ HOUDINI_VERSION_CONFIG = {
         "clang": "clang15.0_14",
         "python": "3.11",
     },
+    "22.0.368": {
+        "gcc": "gcc14.2",
+        "vc": "vc143",
+        "clang": "clang17.0_15",
+        "python": "3.13",
+    },
 }
 
 HOUDINI_CHECKSUMS = {
@@ -62,6 +68,11 @@ HOUDINI_CHECKSUMS = {
         "linux": "a87451f9146d52051a9ba142d535936638351526a48cba0c6156a221f3be58e6",
         "windows": "a78e468e99d1be3476b46062e3a043ecc435751b9a9f92e39bee414ace8ce59e",
         "macos": "3fc918428b22b3c32704d1163a6b1b08723ece71e5e0172e941167549d4d5b25",
+    },
+    "22.0.368": {
+        "linux": "8765335f090a8329768b415b64bc9fb80a0d9963b13f63455ad042e32d353616",
+        "windows": "b72c4ff9fff20e8cc9449ff1dd57dfab4c52421f77b267412fb5c9288b2a3c49",
+        "macos": "a51dedfb764475e1da600432f40d213cd08d628e7ba2f5e3ccf7f8b9ecda6955",
     },
 }
 

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -30,7 +30,13 @@ class HoudiniVersion:
 
     VERSION_REGEX = re.compile(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?")
 
-    PYTHON_VERSIONS = {"19.5": "3.9", "20.0": "3.10", "20.5": "3.11", "21.0": "3.11"}
+    PYTHON_VERSIONS = {
+        "19.5": "3.9",
+        "20.0": "3.10",
+        "20.5": "3.11",
+        "21.0": "3.11",
+        "22.0": "3.13",
+    }
 
     def __init__(self, arg_version: Optional[str] = None):
         version = self._get_houdini_version(arg_version)

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -67,7 +67,7 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         "--prefix",
         installation_path,
         "--enable-components",
-        "deadline_cloud_for_houdini,houdini_19_5,houdini_20_0,houdini_20_5,houdini_21_0",
+        "deadline_cloud_for_houdini,houdini_19_5,houdini_20_0,houdini_20_5,houdini_21_0,houdini_22_0",
         "--houdini-19-5-package-dir",
         installation_path / "houdini19.5" / "packages",
         "--houdini-20-0-package-dir",
@@ -76,6 +76,8 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         installation_path / "houdini20.5" / "packages",
         "--houdini-21-0-package-dir",
         installation_path / "houdini21.0" / "packages",
+        "--houdini-22-0-package-dir",
+        installation_path / "houdini22.0" / "packages",
     ]
     subprocess.run(args, check=True)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

SideFX has released Houdini 22.0. This package supported Houdini 19.5 through 21.0 but had no support for submitting from or rendering with Houdini 22.0.

### What was the solution? (How)

Houdini version handling in this codebase is data-driven, so support is added by registering 22.0 in each per-version configuration point (no version-conditional logic was needed):

- `scripts/install_dev_submitter.py`: map Houdini 22.0 to its bundled Python 3.13 in `PYTHON_VERSIONS`.
- `install_builder/deadline-cloud-for-houdini.xml`: add a `houdini_22_0` installer component (modeled on the `houdini_21_0` block) and update the version-range text to 19.5-22.0.
- `test/installer/test_installer.py`: enable the `houdini_22_0` component and pass `--houdini-22-0-package-dir` in the installer tests.
- `hatch.toml`: add `22.0.368` to the integ-ci matrix.
- `pipeline/setup-runner.py`: add the 22.0.368 entry to `HOUDINI_VERSION_CONFIG` (linux gcc14.2, win64 vc143, macOS arm64 clang17.0_15, Python 3.13) and its per-platform installer SHA256 checksums to `HOUDINI_CHECKSUMS`. The corresponding installers have been uploaded to the CI installer bucket under `houdini/22.0/`.
- `README.md` / `DEVELOPMENT.md`: document 22.0 as supported and its Python version mapping.

All previously supported versions (19.5, 20.0, 20.5, 21.0) remain supported; this change is purely additive.

### What is the impact of this change?

Users can install the submitter plug-in for Houdini 22.0 and submit jobs from it, and the adaptor runs under Houdini 22.0's hython (Python 3.13). CI now covers Houdini 22.0.368 in the integration test matrix.

### How was this change tested?

Tested locally on macOS against Houdini 22.0.368:

- `hatch run test`: 189 passed.
- `hatch run lint`: black, ruff, and mypy all clean.
- Manually installed the dev submitter for 22.0 (`hatch run install --houdini-version 22.0`), opened the submitter panel in Houdini 22.0.368, and submitted a job successfully.

#### Please run the integration tests and paste the results below.

Run with `HOUDINI_VERSION=22.0.368` on macOS (arm64):

```
test/integ/test_houdini_adaptors.py::TestAdaptors::test_minimal_scene_adaptor PASSED
test/integ/test_houdini_adaptors.py::TestAdaptors::test_wedge_node_adaptor PASSED
test/integ/test_houdini_adaptors.py::TestAdaptors::test_render_dependencies_adaptor PASSED
test/integ/test_houdini_adaptors.py::TestAdaptors::test_adaptor_keeps_dcc_open_between_tasks PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_minimal_scene_submitter PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_wedge_node_submitter PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_render_dependencies_submitter PASSED
test/integ/test_houdini_submitters.py::TestSubmitters::test_usd_scene_dependency_detection PASSED
```

All 8 integration tests pass, including Mantra render output compared against the stored expected images (no expected-image regeneration was required for 22.0).

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

Built the installer locally and tested the install of the 22.0 version. Confirmed it worked and the product installed as expected.

### Was this change documented?

Yes. README.md lists 22.0 as a supported version, and DEVELOPMENT.md documents the Python 3.13 mapping for Houdini 22.0.

### Is this a breaking change?

No. This change is additive; all previously supported Houdini versions and existing interfaces are unchanged.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
