### PR TITLE
fix: Houdini 22.0 integ runner setup (libatomic on Linux, macOS prefs perms)

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -3,6 +3,7 @@
 #!/usr/bin/env python3
 """Setup runner for Houdini integration tests in CodeBuild."""
 import argparse
+import getpass
 import hashlib
 import os
 import platform
@@ -135,7 +136,9 @@ def setup_linux(houdini_versions):
         == 0
         else "yum"
     )
-    run([pkg_mgr, "install", "-y", "bc"])
+    # bc is required by the Houdini installer; libatomic provides
+    # libatomic.so.1, which Houdini 22.0's hython links against.
+    run([pkg_mgr, "install", "-y", "bc", "libatomic"])
 
     for version in houdini_versions:
         major_minor = ".".join(version.split(".")[:2])
@@ -364,6 +367,13 @@ def setup_macos(houdini_versions):
             sys.exit(1)
 
         houdini_dmg.unlink(missing_ok=True)
+
+    # The sudo Houdini .pkg installer leaves ~/Library/Preferences/houdini/<ver>
+    # root-owned; hand it back to the build user so the non-sudo submitter install
+    # can write its package JSON. Before the loop so it also runs on cached runners.
+    prefs_root = Path("~/Library/Preferences/houdini").expanduser()
+    prefs_root.mkdir(parents=True, exist_ok=True)
+    run(["sudo", "chown", "-R", f"{getpass.getuser()}:staff", str(prefs_root)], check=False)
 
     print("Installing Houdini submitter...")
     for version in houdini_versions:


### PR DESCRIPTION
## What
Fixes the Houdini 22.0 integration test failures on Linux and macOS introduced when 22.0.368 was added to the integ matrix (#381). Both are runner-setup issues in `pipeline/setup-runner.py`; no product or test-code changes.

## Root causes (from the failed mainline run's CodeBuild/CloudWatch logs)
**Linux** — every integ test failed with exit 127:
```
/opt/hfs22.0.368/bin/hython-bin: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```
Houdini 22.0's `hython` links against `libatomic.so.1`, which isn't present in the CodeBuild image (earlier versions don't need it). `8 failed`, all with this same cause.

**macOS** — failed in setup before any test ran:
```
PermissionError: [Errno 13] Permission denied: '/Users/cbuser/Library/Preferences/houdini/22.0/packages/deadline_submitter_for_houdini.json'
  scripts/install_dev_submitter.py:227 -> open(submitter_package_path, 'w')
```
The Houdini `.pkg` installer runs under `sudo installer` and leaves `~/Library/Preferences/houdini/<ver>` owned by root; the non-sudo submitter install then can't write into it. (19.5/20.0/20.5/21.0 installed fine — their prefs dirs were already user-owned.)

## Changes (`pipeline/setup-runner.py`)
- **Linux:** add `libatomic` to the system packages installed in `setup_linux` (alongside `bc`).
- **macOS:** `chown -R` the `~/Library/Preferences/houdini` tree back to the build user before the submitter-install loop. Placed before the loop (not inside the Houdini-install loop) so it still runs on cached runners that skip the install via the `.installed` marker.

## Notes
- Windows was unaffected and passed.
- DMG/tarball checksums verified OK in the logs — no checksum changes needed.
- `libatomic` is the correct package for the CodeBuild image's `dnf`/`yum` (Amazon Linux), which `setup_linux` already uses.

## Testing
`python -m py_compile` clean; longest added line is 92 chars (repo `line-length = 100`). Full validation is re-running the integ pipeline.