### PR TITLE
fix: macOS integ chown uses wrong user (root instead of cbuser)

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -2,8 +2,8 @@
 
 #!/usr/bin/env python3
 """Setup runner for Houdini integration tests in CodeBuild."""
+
 import argparse
-import getpass
 import hashlib
 import os
 import platform
@@ -371,9 +371,12 @@ def setup_macos(houdini_versions):
     # The sudo Houdini .pkg installer leaves ~/Library/Preferences/houdini/<ver>
     # root-owned; hand it back to the build user so the non-sudo submitter install
     # can write its package JSON. Before the loop so it also runs on cached runners.
-    prefs_root = Path("~/Library/Preferences/houdini").expanduser()
+    prefs_root = (
+        Path(os.environ.get("HOME", str(Path.home()))) / "Library" / "Preferences" / "houdini"
+    )
     prefs_root.mkdir(parents=True, exist_ok=True)
-    run(["sudo", "chown", "-R", f"{getpass.getuser()}:staff", str(prefs_root)], check=False)
+    home_owner = prefs_root.parent.parent.parent.owner()
+    run(["sudo", "chown", "-R", f"{home_owner}:staff", str(prefs_root)], check=False)
 
     print("Installing Houdini submitter...")
     for version in houdini_versions:


### PR DESCRIPTION
## Problem
The macOS integ tests fail with:
```
PermissionError: [Errno 13] Permission denied: '/Users/cbuser/Library/Preferences/houdini/19.5/packages/deadline_submitter_for_houdini.json'
```

The chown added in #384 uses `getpass.getuser()`, which returns `root` because the script runs as root on the macOS runner. So the chown does `sudo chown -R root:staff` — making the directory **more** root-owned, not less.

## Fix
Replace `getpass.getuser()` with `prefs_root.parent.parent.parent.owner()` — the filesystem owner of `/Users/cbuser` (which is `cbuser` regardless of who the running process is).

## Verified
- Linux integ already passes (2 consecutive green runs since #384 merged the `libatomic` fix).
- Logic validated locally: `Path('/Users/<user>').owner()` returns the dir owner even when invoked as root.