### PR TITLE
feat: enable deadline-cloud-v2 conda channel in submitter

### DIFF
--- a/src/deadline/houdini_submitter/panel/submitter_panel.py
+++ b/src/deadline/houdini_submitter/panel/submitter_panel.py
@@ -283,6 +283,7 @@ def onCreateInterface():
         ),
         f=Qt.Tool,
         show_host_requirements_tab=True,
+        use_deadline_cloud_v2_channel=True,
     )
 
     # The shared dialog closes itself after a successful submission

--- a/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
+++ b/src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py
@@ -1230,6 +1230,7 @@ def submit_callback(kwargs):
             ),
             f=Qt.Tool,
             show_host_requirements_tab=True,
+            use_deadline_cloud_v2_channel=True,
             parent=hou.qt.mainWindow(),
         )
         # Run the pre-submission checks when Submit is clicked, before the dialog opens its modal


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Houdini 22.0 is published only to the `deadline-cloud-v2` Conda channel. Submitting from a queue
whose `CondaChannels` still resolves to `deadline-cloud` therefore fails during the Conda solve:

```
No candidates were found for houdini 22.0.*.
openjd_fail: Environment solve failed
```

`deadline-cloud` >= 0.60 exposes `use_deadline_cloud_v2_channel` on `SubmitJobToDeadlineDialog`.
When enabled it prepends `deadline-cloud-v2` ahead of `deadline-cloud` in the `CondaChannels`
queue parameter as it loads from the queue, keeping `deadline-cloud` as a fallback and leaving
other channels untouched. The Houdini submitter had not opted in, so Houdini 22.0 support added
in #381 is not reachable from a default-configured queue.

### What was the solution? (How)

Pass `use_deadline_cloud_v2_channel=True` at both `SubmitJobToDeadlineDialog` construction sites:

- `src/deadline/houdini_submitter/panel/submitter_panel.py` (Python panel)
- `src/deadline/houdini_submitter/python/deadline_cloud_for_houdini/submitter.py` (ROP submit callback)

This matches the Maya, Blender, Cinema 4D, Nuke and VRED submitters, which already pass this flag.

### What is the impact of this change?

Submissions resolve Houdini 22.0 from `deadline-cloud-v2`. Existing versions are unaffected:

- Houdini 19.5, 20.0, 20.5 and 21.0 are all published in `deadline-cloud-v2` at the same versions,
  so nothing that resolved before stops resolving.
- `channel_priority` is `flexible`, so packages published only to `deadline-cloud` — for example
  older `houdini-openjd` builds — continue to resolve from it. Verified by resolving a
  legacy-only combination with both channels configured (see below).

This only affects the GUI submission path. The headless `HoudiniSubmitter` continues to use
whatever `queue_parameters` the caller supplies.

### How was this change tested?

- `hatch run test` — 201 passed
- `hatch run lint` — `ruff`, `black` and `mypy` all clean

Additionally validated against Houdini 22.0.368 on a Linux service-managed fleet:

- With `deadline-cloud-v2`: resolves `houdini 22.0.368` and `houdini-openjd 0.7.11`, and a Karma
  render completes with the EXR returned via job attachments.
- With `deadline-cloud` only: fails with `No candidates were found for houdini 22.0.*`, which is
  the failure this change avoids.
- With both channels configured, a legacy-only combination (`houdini=19.5.*` with
  `houdini-openjd=0.6.*`) still resolves, installing Houdini from `deadline-cloud-v2` and the
  adaptor from `deadline-cloud` — confirming the fallback behaviour.

#### Please run the integration tests and paste the results below.

Not run. The integration tests require an interactive Houdini 22 license, which I do not currently
have access to; the validation above was performed with the headless submitter and adaptor on a
render farm instead. Happy for a maintainer with a licensed workstation to run them.

### Was this change documented?

No documentation change needed — no public interface, docstring, or adaptor init-data/run-data
schema is affected.

### Is this a breaking change?

No. The `deadline-cloud` channel is retained as a fallback, so previously resolvable package
sets continue to resolve.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
