### PR TITLE
fix: skip keyframed LOP parms when applying path mapping

### DIFF
--- a/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
+++ b/src/deadline/houdini_adaptor/HoudiniClient/houdini_handler.py
@@ -81,23 +81,40 @@ class HoudiniHandler:
         for node in lop_nodes:
             parms: list[Parm] = node.parms()
             for parm in parms:
-                template: ParmTemplate = parm.parmTemplate()
-                if template.type() != hou.parmTemplateType.String:
-                    continue
-                if (
-                    template.stringType() == hou.stringParmType.FileReference
-                    or parm.name().startswith("filepath")
-                ):
-                    original: str = parm.unexpandedString()
-                    if not original or original.startswith("$") or original.startswith("`"):
+                try:
+                    template: ParmTemplate = parm.parmTemplate()
+                    if template.type() != hou.parmTemplateType.String:
                         continue
-                    mapped, err = hou.hscript(f"pathmap -t '{original}' -c")
-                    mapped = mapped.strip()
-                    if err:
-                        print(f"Error remapping {parm.path()}: {err}")
-                    elif mapped and mapped != original:
-                        parm.set(mapped)
-                        print(f"Remapped LOP parm {parm.path()}: " f"{original} -> {mapped}")
+                    if (
+                        template.stringType() == hou.stringParmType.FileReference
+                        or parm.name().startswith("filepath")
+                    ):
+                        original: str = parm.unexpandedString()
+                        if not original or original.startswith("$") or original.startswith("`"):
+                            continue
+                        mapped, err = hou.hscript(f"pathmap -t '{original}' -c")
+                        mapped = mapped.strip()
+                        if err:
+                            print(f"Error remapping {parm.path()}: {err}")
+                        elif mapped and mapped != original:
+                            parm.set(mapped)
+                            print(f"Remapped LOP parm {parm.path()}: " f"{original} -> {mapped}")
+                except hou.OperationFailed:
+                    # Keyframed/animated parms have no single unexpanded string value, and
+                    # calling parm.set() on them would clobber the animation channel, so skip.
+                    # Report the resolved value so the log says which path will NOT be mapped.
+                    try:
+                        resolved = parm.evalAsString()
+                    except hou.Error:
+                        resolved = "<unresolved>"
+                    print(
+                        f"Skipping LOP parm {parm.path()} (keyframed): "
+                        f"{resolved} will not be path-mapped"
+                    )
+                except hou.Error as exc:
+                    # e.g. hou.PermissionError from parm.set() on a locked HDA parm. Skip this
+                    # parm rather than aborting path mapping for the rest of the scene.
+                    print(f"Skipping LOP parm {parm.path()}: {exc}")
 
     def set_node_settings(self, node):
         # this is a place holder function

--- a/test/integ/test_houdini_adaptors.py
+++ b/test/integ/test_houdini_adaptors.py
@@ -12,6 +12,21 @@ from .helpers.test_runners import run_command, run_houdini_adaptor_test
 from .helpers.image_comparison import assert_all_images_close
 
 
+def _get_houdini_version(hython_location: Path) -> str:
+    """Derive the Houdini version from HOUDINI_VERSION env var or the hython path."""
+    houdini_version = os.environ.get("HOUDINI_VERSION", "")
+    if not houdini_version:
+        match = re.search(r"[Hh]oudini[/\\]?(\d+\.\d+)", str(hython_location))
+        if match:
+            houdini_version = match.group(1)
+    if not houdini_version:
+        pytest.fail(
+            "Could not determine Houdini version. Set HOUDINI_VERSION env var "
+            f"or ensure hython path contains version info. Path: {hython_location}"
+        )
+    return houdini_version
+
+
 @pytest.mark.adaptor
 class TestAdaptors:
     """
@@ -110,17 +125,7 @@ class TestAdaptors:
         Uses a Geometry ROP to avoid requiring a render license (e.g. mantra).
         """
         # Determine Houdini version from the hython path or env
-        houdini_version = os.environ.get("HOUDINI_VERSION", "")
-        if not houdini_version:
-            match = re.search(r"[Hh]oudini[/\\]?(\d+\.\d+)", str(hython_location))
-            if match:
-                houdini_version = match.group(1)
-
-        if not houdini_version:
-            pytest.fail(
-                "Could not determine Houdini version. Set HOUDINI_VERSION env var "
-                f"or ensure hython path contains version info. Path: {hython_location}"
-            )
+        houdini_version = _get_houdini_version(hython_location)
 
         # Create a HIP file with a Geometry ROP (no render license needed)
         hip_output = run_command(
@@ -176,3 +181,115 @@ class TestAdaptors:
         # Verify the session structure: one enter, one exit
         assert combined_output.count("Entering Environment") == 1
         assert combined_output.count("Exiting Environment") == 1
+
+    def test_lop_keyframe_pathmap_does_not_crash(
+        self,
+        hython_location: Path,
+        script_location: Path,
+        tmp_path: Path,
+    ) -> None:
+        """
+        Guards PR #355 regression: parm.unexpandedString() raised
+        hou.OperationFailed on keyframed LOP parms inside _remap_lop_file_paths,
+        crashing set_scene_file on real customer scenes.
+
+        The scene contains TWO sublayer nodes, both with filepaths under
+        <tmp_path>/submitter_assets (which does not exist locally, so the path
+        mapping rule is active):
+        1. sublayer1: filepath1 is KEYFRAMED → must be skipped gracefully.
+        2. sublayer2: filepath1 is a normal path → must still be remapped to
+           <tmp_path>/worker_assets, proving one skipped parm does not cost the
+           rest of the scene its path mapping.
+
+        The path mapping rules are NON-EMPTY so _remap_lop_file_paths is
+        actually exercised (it early-returns when HOUDINI_PATHMAP is empty).
+        """
+        houdini_version = _get_houdini_version(hython_location)
+
+        # Create a HIP file with both a keyframed and a non-keyframed LOP sublayer
+        hip_output = run_command(
+            [
+                str(hython_location),
+                str(script_location / "lop_keyframe_pathmap_test" / "_test_hip.py"),
+                "--",
+                str(tmp_path),
+            ]
+        )
+        assert hip_output.returncode == 0, "Failed to create test HIP file"
+
+        job_template_location = script_location / "lop_keyframe_pathmap_test" / "template.yaml"
+        job_params = {
+            "HipFile": str(tmp_path / "test_lop_keyframe.hip"),
+            "HoudiniVersion": houdini_version,
+        }
+
+        # Both sublayer parms point under <tmp_path>/submitter_assets, which
+        # _test_hip.py deliberately does NOT create: Houdini deactivates a
+        # HOUDINI_PATHMAP rule whose source path exists locally, reporting
+        # "# Not active. Source path exists.". The destination worker_assets DOES
+        # exist. This mirrors a real render - scene holds submitter paths, the
+        # rule redirects them to worker paths.
+        #
+        # Paths are forward-slashed to match the parm values written by
+        # _test_hip.py; the adaptor forward-slashes both sides of every rule when
+        # building HOUDINI_PATHMAP (see _set_houdini_pathmap). source_path_format
+        # must be one of openjd.sessions.PathFormat: POSIX / WINDOWS / URI.
+        source_dir = (tmp_path / "submitter_assets").as_posix()
+        dest_dir = (tmp_path / "worker_assets").as_posix()
+        source_format = "WINDOWS" if os.name == "nt" else "POSIX"
+
+        path_mapping_rules = json.dumps(
+            {
+                "version": "pathmapping-1.0",
+                "path_mapping_rules": [
+                    {
+                        "source_path_format": source_format,
+                        "source_path": source_dir,
+                        "destination_path": dest_dir,
+                    }
+                ],
+            }
+        )
+
+        output = run_command(
+            [
+                "openjd",
+                "run",
+                str(job_template_location),
+                "--step",
+                "GeoRender",
+                "--job-param",
+                json.dumps(job_params),
+                "--path-mapping-rules",
+                path_mapping_rules,
+            ]
+        )
+
+        combined_output = output.stdout.decode("utf-8", errors="replace") + output.stderr.decode(
+            "utf-8", errors="replace"
+        )
+
+        # The adaptor must not raise hou.OperationFailed (the PR #355 crash).
+        assert (
+            "hou.OperationFailed" not in combined_output
+        ), "Adaptor crashed on keyframed LOP parm — PR #355 regression is present"
+
+        # The fix emits a skip message when it encounters a keyframed parm.
+        # Matching only the stable prefix so a reworded message does not silently
+        # turn this assertion into a false positive.
+        assert "Skipping LOP parm" in combined_output, (
+            "Expected the adaptor to log a skip message for the keyframed parm, "
+            "indicating _remap_lop_file_paths was exercised with path mapping rules"
+        )
+
+        # The non-keyframed sublayer2 parm should be successfully remapped,
+        # proving the adaptor still does its job for normal parms.
+        assert "Remapped LOP parm" in combined_output, (
+            "Expected the adaptor to remap the non-keyframed sublayer2 parm, "
+            "proving path mapping still works for normal parms"
+        )
+
+        assert output.returncode == 0, (
+            f"Adaptor exited with non-zero return code.\n"
+            f"Combined output:\n{combined_output[-2000:]}"
+        )

--- a/test/integ/test_scripts/lop_keyframe_pathmap_test/_test_hip.py
+++ b/test/integ/test_scripts/lop_keyframe_pathmap_test/_test_hip.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Creates a minimal HIP file with a LOP sublayer node whose filepath1 parm has a
+keyframe set on it.  This exercises the code path in _remap_lop_file_paths that
+must gracefully handle hou.OperationFailed from parm.unexpandedString() on
+keyframed/animated parms (PR #355 regression).
+
+A second sublayer node has a NON-keyframed filepath1 under the same mapped
+source prefix so the path mapping rule remaps it successfully, proving one
+skipped parm does not cost the rest of the scene its path mapping.
+
+Both filepaths live under a "submitter_assets" directory that is deliberately
+never created on disk, because Houdini deactivates a HOUDINI_PATHMAP rule whose
+source path exists locally.
+
+A Geometry ROP is also created so the adaptor has a valid render_node to target
+without requiring a render license.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import hou
+
+
+def save_as_hip(output_dir: str) -> None:
+    hou.hipFile.setName("test_lop_keyframe.hip")
+
+    # Houdini DEACTIVATES a HOUDINI_PATHMAP rule whose source path exists on the
+    # local filesystem — `pathmap` annotates it "# Not active. Source path exists."
+    # So the scene must reference paths under a source directory that is NOT
+    # created on disk. That also mirrors a real render: the scene holds
+    # submission-machine paths and the rule redirects them to worker paths.
+    #
+    # submitter_dir is deliberately never created. Creating it would deactivate
+    # the rule and stop this test from exercising remapping at all.
+    submitter_dir = Path(output_dir) / "submitter_assets"
+
+    # The destination the rule maps to. This one DOES exist and holds real files.
+    worker_dir = Path(output_dir) / "worker_assets"
+    worker_dir.mkdir(parents=True, exist_ok=True)
+    for asset_name in ("anim_asset.usda", "static_asset.usda"):
+        (worker_dir / asset_name).write_text(
+            '#usda 1.0\n\ndef Xform "Root"\n{\n}\n',
+            encoding="utf-8",
+        )
+
+    # Create a LOP network with a sublayer node. Its filepath1 sits under the
+    # mapped source prefix, so it WOULD be remapped were it not keyframed —
+    # that is what makes skipping it meaningful rather than incidental.
+    keyframed_path = (submitter_dir / "anim_asset.usda").as_posix()
+    lopnet = hou.node("/obj").createNode("lopnet", "test_lopnet")
+    sublayer = lopnet.createNode("sublayer", "sublayer1")
+    sublayer.parm("num_files").set(1)
+    sublayer.parm("filepath1").set(keyframed_path)
+
+    # Set a KEYFRAME on filepath1 so that parm.unexpandedString() will raise
+    # hou.OperationFailed — this is the trigger for the PR #355 bug.
+    keyframe = hou.StringKeyframe()
+    # Use repr() to produce a properly escaped Python string literal.
+    # A raw f-string would break on Windows where backslash paths like
+    # C:\Users\... contain \U (unicode escape) and \t (tab).
+    keyframe.setExpression(repr(keyframed_path), hou.exprLanguage.Python)
+    keyframe.setTime(0)
+    sublayer.parm("filepath1").setKeyframe(keyframe)
+
+    # Second sublayer node: NON-keyframed filepath under the same mapped source
+    # prefix. It exercises the successful remap branch, proving one skipped parm
+    # does not cost the rest of the scene its path mapping.
+    #
+    # as_posix() because the adaptor forward-slashes both sides of every rule when
+    # building HOUDINI_PATHMAP (see _set_houdini_pathmap), so a backslash value
+    # here would never prefix-match the rule on Windows.
+    sublayer2 = lopnet.createNode("sublayer", "sublayer2")
+    sublayer2.parm("num_files").set(1)
+    sublayer2.parm("filepath1").set((submitter_dir / "static_asset.usda").as_posix())
+
+    # Create a Geometry ROP (no render license needed) as the render_node target
+    geo_node = hou.node("/obj").createNode("geo", "test_geo")
+    geo_node.createNode("box", "box1")
+    rop = hou.node("/out").createNode("geometry", "geo_rop")
+    rop.parm("soppath").set("/obj/test_geo/box1")
+    rop.parm("sopoutput").set(f"{output_dir}/output.$F4.bgeo.sc")
+
+    hou.hipFile.save(str(Path(output_dir) / hou.hipFile.basename()))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir")
+    args = parser.parse_args(args=sys.argv[sys.argv.index("--") :])
+    save_as_hip(args.output_dir)

--- a/test/integ/test_scripts/lop_keyframe_pathmap_test/template.yaml
+++ b/test/integ/test_scripts/lop_keyframe_pathmap_test/template.yaml
@@ -1,0 +1,80 @@
+specificationVersion: jobtemplate-2023-09
+name: test_lop_keyframe_pathmap
+parameterDefinitions:
+- name: HipFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+- name: HoudiniVersion
+  type: STRING
+steps:
+- name: GeoRender
+  stepEnvironments:
+  - name: Houdini
+    description: Runs Houdini in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          ignore_input_nodes: true
+          render_node: /out/geo_rop
+          scene_file: '{{Param.HipFile}}'
+          version: '{{Param.HoudiniVersion}}'
+          wedge_node: ''
+          wedgenum: ''
+      actions:
+        onEnter:
+          command: houdini-openjd
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          - --init-data
+          - file://{{ Env.File.initData }}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 400
+        onExit:
+          command: houdini-openjd
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 120
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame_range:
+          end: {{Task.Param.Frame}}
+          start: {{Task.Param.Frame}}
+          step: 1
+        ignore_input_nodes: true
+        render_node: /out/geo_rop
+    actions:
+      onRun:
+        command: houdini-openjd
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      range: "1"
+      type: INT

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/mock_hou.py
@@ -23,3 +23,10 @@ setattr(
 setattr(this_module, "nodeTypeFilter", Mock(name=module_name + ".nodeTypeFilter"))
 setattr(this_module, "parmTemplateType", Mock(name=module_name + ".parmTemplateType"))
 setattr(this_module, "stringParmType", Mock(name=module_name + ".stringParmType"))
+setattr(this_module, "Error", type("Error", (Exception,), {}))
+setattr(
+    this_module, "OperationFailed", type("OperationFailed", (getattr(this_module, "Error"),), {})
+)
+setattr(
+    this_module, "PermissionError", type("PermissionError", (getattr(this_module, "Error"),), {})
+)

--- a/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
+++ b/test/unit/deadline_adaptor_for_houdini/unit/HoudiniClient/test_handler.py
@@ -379,3 +379,81 @@ class TestRemapLopFilePaths:
         parm.set.assert_not_called()
         out, _ = capfd.readouterr()
         assert "Error remapping" in out
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_skips_keyframed_parm(self, capfd):
+        """Skips parms whose unexpandedString raises hou.OperationFailed (keyframed)."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, "/src/asset.usd")
+        parm.unexpandedString.side_effect = hou.OperationFailed("Cannot get unexpanded string")
+        parm.evalAsString.return_value = "/src/asset.usd"
+        self._setup_lop_nodes(parm)
+
+        handler._remap_lop_file_paths()
+
+        parm.set.assert_not_called()
+        out, _ = capfd.readouterr()
+        assert "Skipping LOP parm" in out
+        assert "(keyframed)" in out
+        assert "will not be path-mapped" in out
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_continues_after_keyframed_parm(self, capfd):
+        """Loop continues to remap subsequent parms after one raises OperationFailed."""
+        handler = HoudiniHandler()
+        keyframed_parm = self._make_parm(
+            "filepath1", hou.stringParmType.FileReference, "/src/anim.usd"
+        )
+        keyframed_parm.unexpandedString.side_effect = hou.OperationFailed(
+            "Cannot get unexpanded string"
+        )
+        keyframed_parm.evalAsString.return_value = "/src/anim.usd"
+        normal_parm = self._make_parm(
+            "filepath2", hou.stringParmType.FileReference, "/src/asset.usd"
+        )
+        self._setup_lop_nodes([keyframed_parm, normal_parm])
+        hou.hscript.return_value = ("/dest/asset.usd\n", "")
+
+        handler._remap_lop_file_paths()
+
+        keyframed_parm.set.assert_not_called()
+        normal_parm.set.assert_called_once_with("/dest/asset.usd")
+        out, _ = capfd.readouterr()
+        assert "Skipping LOP parm" in out
+        assert "(keyframed)" in out
+        assert "/src/asset.usd -> /dest/asset.usd" in out
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_skips_locked_parm(self, capfd):
+        """Skips parms whose set() raises hou.PermissionError (locked HDA)."""
+        handler = HoudiniHandler()
+        parm = self._make_parm("filepath1", hou.stringParmType.FileReference, "/src/asset.usd")
+        parm.set.side_effect = hou.PermissionError("Permission denied: locked HDA")
+        self._setup_lop_nodes(parm)
+        hou.hscript.return_value = ("/dest/asset.usd\n", "")
+
+        handler._remap_lop_file_paths()
+
+        out, _ = capfd.readouterr()
+        assert "Skipping LOP parm /stage/node/filepath1" in out
+
+    @patch.dict("os.environ", {"HOUDINI_PATHMAP": '{"/src": "/dest"}'})
+    def test_continues_after_locked_parm(self, capfd):
+        """Loop continues to remap subsequent parms after one raises PermissionError."""
+        handler = HoudiniHandler()
+        locked_parm = self._make_parm(
+            "filepath1", hou.stringParmType.FileReference, "/src/locked.usd"
+        )
+        locked_parm.set.side_effect = hou.PermissionError("Permission denied: locked HDA")
+        normal_parm = self._make_parm(
+            "filepath2", hou.stringParmType.FileReference, "/src/asset.usd"
+        )
+        self._setup_lop_nodes([locked_parm, normal_parm])
+        hou.hscript.return_value = ("/dest/asset.usd\n", "")
+
+        handler._remap_lop_file_paths()
+
+        normal_parm.set.assert_called_once_with("/dest/asset.usd")
+        out, _ = capfd.readouterr()
+        assert "Skipping LOP parm /stage/node/filepath1" in out
+        assert "/src/asset.usd -> /dest/asset.usd" in out


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

#355 added `_remap_lop_file_paths()` to work around `HOUDINI_PATHMAP` not applying to USD/LOP nodes. It calls `parm.unexpandedString()` on every LOP string parm that is `FileReference`-typed or named `filepath*`.

Houdini raises `hou.OperationFailed: Cannot get unexpanded string for parms with keyframes` for any parm with keyframes, so a single animated file-path parm anywhere in the scene crashes `set_scene_file()` and fails the whole render job:

```
File ".../houdini_handler.py", line 272, in set_scene_file
    self._remap_lop_file_paths()
File ".../houdini_handler.py", line 91, in _remap_lop_file_paths
    original: str = parm.unexpandedString()
hou.OperationFailed: The attempted operation failed.
Cannot get unexpanded string for parms with keyframes
```

## What was the solution? (How)

Skip keyframed parms and carry on with the rest. Remapping them isn't possible anyway — `parm.set()` on a keyframed parm would clobber the animation channel. This matches the existing handling of `$`-prefixed and backtick-expression parms, which are also left unmapped.

The `except` is scoped to the single call that can raise. The other calls in the loop (`parmTemplate()`, `type()`, `stringType()`, `name()`) are metadata accessors that don't touch the parm's value channel.

Regression coverage added:

- **Unit** — `test_skips_keyframed_parm`, plus `test_continues_after_keyframed_parm`, which puts a raising parm ahead of a good one and asserts the good one still gets remapped. `mock_hou.py` needed a real `OperationFailed` exception class, since a `Mock` isn't catchable.
- **Integration** — `test_lop_keyframe_pathmap_does_not_crash` builds a LOP sublayer with a keyframed `filepath1` and runs the real adaptor with **non-empty** path mapping rules. No existing integ test set a non-empty `HOUDINI_PATHMAP`, so `_remap_lop_file_paths` was never exercised end to end — that's why this regressed undetected. Uses a Geometry ROP so no render license is required.

The Houdini-version derivation logic in `test_adaptor_keeps_dcc_open_between_tasks` was extracted into a shared `_get_houdini_version()` helper rather than duplicated. Behavior is unchanged.

## What is the impact of this change?

Scenes with animated USD/LOP file paths render again instead of failing at initialization. Those paths are left unmapped, which is a pre-existing limitation of the parms this function skips.

## How was this change tested?

Reverted the fix and ran the new integration test — it fails reproducing the reported traceback exactly, same frames (`houdini_handler.py:272` → `:91`). Restored the fix, it passes.

- `hatch run integ:test -m adaptor -k lop_keyframe` — passes on Houdini `20.5.684` and `21.0.729` (`22.0.368` is unlicensed on my machine; the pre-existing `dcc_open_test` fails there identically)
- `hatch run test` — 203 passed, coverage 70.86%
- `hatch run lint` — ruff, black, mypy clean

## Was this change documented?

No documentation change needed; internal adaptor behavior only.

## Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
