### PR TITLE
docs: document pre-GUI submission hooks for Houdini

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ability to run Houdini efficiently on your render farm.
 [default-queue-environment]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment
 [deadline-cloud-submitter]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html
 [deadline-cloud-monitor]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitor-onboarding.html
+[submission-hooks]: https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md
 
 ## Compatibility
 
@@ -103,6 +104,24 @@ hosts do not have any rendering applications pre-installed. The standard way of 
 You can find a list of the versions of Houdini that are available by default
 [in the user guide](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment)
 if you are using the default Conda queue enivonment in your setup.
+
+## Submission Hooks
+
+This submitter supports [Deadline Cloud submission hooks][submission-hooks] — the **pre-GUI** hook
+(pre-populates the submission dialog before it opens) and the **pre-submission** / **post-submission**
+hooks (run at submit time). Hooks are sourced from the directory named by the `DEADLINE_HOOKS_DIR`
+environment variable; enable environment-sourced hooks with:
+
+```
+deadline config set settings.allow_environment_hooks true
+```
+
+For Houdini, pre-GUI hooks run when the Deadline Cloud submission panel opens — i.e. when you select
+the Deadline Cloud ROP in the `/out` network so its panel appears.
+
+See [`docs/submission-hooks.md`][submission-hooks] in the base client library for the rest: the
+`hooks.yaml` format, hook input/output, version requirements, the confirmation prompt, and security
+guidance.
 
 ## Viewing the Job Bundle that will be submitted
 


### PR DESCRIPTION
Fixes: *N/A — documentation follow-up to #364.*

### What was the problem/requirement? (What/Why)

The Houdini submitter runs submission hooks (pre-GUI shipped in #364; pre/post-submission via the client), but `mainline` had no mention of it — an artist/TD reading this README wouldn't know hooks are supported or how to turn them on. Rather than duplicate the client library's hooks documentation, this points readers at it (matching how the base `deadline-cloud` README references `docs/submission-hooks.md`).

### What was the solution? (How)

Docs-only: adds a short **Submission Hooks** section to `README.md` stating that the submitter supports Deadline Cloud submission hooks (pre-GUI and pre/post-submission), sourced from `DEADLINE_HOOKS_DIR` and enabled with `deadline config set settings.allow_environment_hooks true`, plus the Houdini launch path (the `/out` Deadline Cloud ROP panel). It links `deadline-cloud/blob/mainline/docs/submission-hooks.md` for the full details (`hooks.yaml` format, hook I/O, version requirements, confirmation prompt, security). No code changes.

### What is the impact of this change?

Documentation only — no source, adaptor, installer, or schema changes.

### How was this change tested?

Docs-only change; no code paths were modified.

- Have you run the unit tests? N/A — no code changed. Verified the Markdown renders and the base-doc link resolves.

#### Please run the integration tests and paste the results below.

N/A — documentation-only change.

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below.

N/A — only `README.md` changed.

### Was this change documented?

Yes — this change *is* the documentation (README only; this repo keeps no user-facing DCC docs under `docs/`). No docstrings or adaptor init-data/run-data schemas were affected.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
